### PR TITLE
x64 assembly for (128-bit / 64-bit) = 64-bit

### DIFF
--- a/include/fast_div.hpp
+++ b/include/fast_div.hpp
@@ -101,6 +101,7 @@ fast_div64(X x, Y y)
 #endif
 }
 
+/// (?-bit / 64-bit) = 64-bit
 template <typename X, typename Y>
 typename std::enable_if<!(sizeof(X) == sizeof(uint64_t) * 2 &&
                           sizeof(Y) <= sizeof(uint64_t)), uint64_t>::type

--- a/include/fast_div.hpp
+++ b/include/fast_div.hpp
@@ -67,12 +67,11 @@ fast_div(X x, Y y)
 }
 
 /// Optimized (128-bit / 64-bit) = 64-bit, for x64.
-/// uint64_t fast_div(uint128_t x, uint64_t x)
-template <typename R, typename X, typename Y>
-typename std::enable_if<(sizeof(R) == sizeof(uint64_t) &&
-                         sizeof(X) == sizeof(uint64_t) * 2 &&
-                         sizeof(Y) <= sizeof(uint64_t)), R>::type
-fast_div(X x, Y y)
+/// uint64_t fast_div64(uint128_t x, uint64_t x)
+template <typename X, typename Y>
+typename std::enable_if<(sizeof(X) == sizeof(uint64_t) * 2 &&
+                         sizeof(Y) <= sizeof(uint64_t)), uint64_t>::type
+fast_div64(X x, Y y)
 {
 #if defined(__x86_64__) && \
    (defined(__GNUC__) || defined(__clang__))
@@ -98,17 +97,16 @@ fast_div(X x, Y y)
 
   return result;
 #else
-  return (R) fast_div(x, y);
+  return (uint64_t) fast_div(x, y);
 #endif
 }
 
-template <typename R, typename X, typename Y>
-typename std::enable_if<!(sizeof(R) == sizeof(uint64_t) &&
-                          sizeof(X) == sizeof(uint64_t) * 2 &&
-                          sizeof(Y) <= sizeof(uint64_t)), R>::type
-fast_div(X x, Y y)
+template <typename X, typename Y>
+typename std::enable_if<!(sizeof(X) == sizeof(uint64_t) * 2 &&
+                          sizeof(Y) <= sizeof(uint64_t)), uint64_t>::type
+fast_div64(X x, Y y)
 {
-  return (R) fast_div(x, y);
+  return (uint64_t) fast_div(x, y);
 }
 
 } // namespace

--- a/src/deleglise-rivat/S2_easy.cpp
+++ b/src/deleglise-rivat/S2_easy.cpp
@@ -73,9 +73,9 @@ T S2_easy_OpenMP(T x,
     // where phi(x / n, b - 1) = pi(x / n) - b + 2
     while (l > pi_min_clustered)
     {
-      int64_t xn = fast_div<int64_t>(x2, primes[l]);
+      int64_t xn = fast_div64(x2, primes[l]);
       int64_t phi_xn = pi[xn] - b + 2;
-      int64_t xm = fast_div<int64_t>(x2, primes[b + phi_xn - 1]);
+      int64_t xm = fast_div64(x2, primes[b + phi_xn - 1]);
       int64_t l2 = pi[xm];
       s2_easy += phi_xn * (l - l2);
       l = l2;
@@ -86,7 +86,7 @@ T S2_easy_OpenMP(T x,
     // x / n <= y && phi(x / n, b - 1) = pi(x / n) - b + 2
     for (; l > pi_min_sparse; l--)
     {
-      int64_t xn = fast_div<int64_t>(x2, primes[l]);
+      int64_t xn = fast_div64(x2, primes[l]);
       s2_easy += pi[xn] - b + 2;
     }
 

--- a/src/deleglise-rivat/S2_easy.cpp
+++ b/src/deleglise-rivat/S2_easy.cpp
@@ -73,9 +73,9 @@ T S2_easy_OpenMP(T x,
     // where phi(x / n, b - 1) = pi(x / n) - b + 2
     while (l > pi_min_clustered)
     {
-      int64_t xn = (int64_t) fast_div(x2, primes[l]);
+      int64_t xn = fast_div<int64_t>(x2, primes[l]);
       int64_t phi_xn = pi[xn] - b + 2;
-      int64_t xm = (int64_t) fast_div(x2, primes[b + phi_xn - 1]);
+      int64_t xm = fast_div<int64_t>(x2, primes[b + phi_xn - 1]);
       int64_t l2 = pi[xm];
       s2_easy += phi_xn * (l - l2);
       l = l2;
@@ -86,7 +86,7 @@ T S2_easy_OpenMP(T x,
     // x / n <= y && phi(x / n, b - 1) = pi(x / n) - b + 2
     for (; l > pi_min_sparse; l--)
     {
-      int64_t xn = (int64_t) fast_div(x2, primes[l]);
+      int64_t xn = fast_div<int64_t>(x2, primes[l]);
       s2_easy += pi[xn] - b + 2;
     }
 

--- a/src/deleglise-rivat/S2_easy_libdivide.cpp
+++ b/src/deleglise-rivat/S2_easy_libdivide.cpp
@@ -13,6 +13,7 @@
 
 #include <PiTable.hpp>
 #include <primecount-internal.hpp>
+#include <fast_div.hpp>
 #include <generate.hpp>
 #include <int128_t.hpp>
 #include <min.hpp>
@@ -117,9 +118,9 @@ T S2_easy_OpenMP(T x,
       // where phi(x / n, b - 1) = pi(x / n) - b + 2
       while (l > pi_min_clustered)
       {
-        int64_t xn = (int64_t) (x2 / primes[l]);
+        int64_t xn = fast_div<int64_t>(x2, primes[l]);
         int64_t phi_xn = pi[xn] - b + 2;
-        int64_t xm = (int64_t) (x2 / primes[b + phi_xn - 1]);
+        int64_t xm = fast_div<int64_t>(x2, primes[b + phi_xn - 1]);
         int64_t l2 = pi[xm];
         s2_easy += phi_xn * (l - l2);
         l = l2;
@@ -130,7 +131,7 @@ T S2_easy_OpenMP(T x,
       // x / n <= y && phi(x / n, b - 1) = pi(x / n) - b + 2
       for (; l > pi_min_sparse; l--)
       {
-        int64_t xn = (int64_t) (x2 / primes[l]);
+        int64_t xn = fast_div<int64_t>(x2, primes[l]);
         s2_easy += pi[xn] - b + 2;
       }
     }

--- a/src/deleglise-rivat/S2_easy_libdivide.cpp
+++ b/src/deleglise-rivat/S2_easy_libdivide.cpp
@@ -118,9 +118,9 @@ T S2_easy_OpenMP(T x,
       // where phi(x / n, b - 1) = pi(x / n) - b + 2
       while (l > pi_min_clustered)
       {
-        int64_t xn = fast_div<int64_t>(x2, primes[l]);
+        int64_t xn = fast_div64(x2, primes[l]);
         int64_t phi_xn = pi[xn] - b + 2;
-        int64_t xm = fast_div<int64_t>(x2, primes[b + phi_xn - 1]);
+        int64_t xm = fast_div64(x2, primes[b + phi_xn - 1]);
         int64_t l2 = pi[xm];
         s2_easy += phi_xn * (l - l2);
         l = l2;
@@ -131,7 +131,7 @@ T S2_easy_OpenMP(T x,
       // x / n <= y && phi(x / n, b - 1) = pi(x / n) - b + 2
       for (; l > pi_min_sparse; l--)
       {
-        int64_t xn = fast_div<int64_t>(x2, primes[l]);
+        int64_t xn = fast_div64(x2, primes[l]);
         s2_easy += pi[xn] - b + 2;
       }
     }

--- a/src/deleglise-rivat/S2_hard.cpp
+++ b/src/deleglise-rivat/S2_hard.cpp
@@ -109,7 +109,7 @@ T S2_hard_thread(T x,
         if (prime < factor.lpf(m))
         {
           int64_t fm = factor.get_number(m);
-          int64_t xn = (int64_t) fast_div(x2, fm);
+          int64_t xn = fast_div<int64_t>(x2, fm);
           int64_t stop = xn - low;
           count += sieve.count(start, stop, low, high, count, count_low_high);
           start = stop + 1;
@@ -142,7 +142,7 @@ T S2_hard_thread(T x,
 
       for (; primes[l] > min_hard; l--)
       {
-        int64_t xn = (int64_t) fast_div(x2, primes[l]);
+        int64_t xn = fast_div<int64_t>(x2, primes[l]);
         int64_t stop = xn - low;
         count += sieve.count(start, stop, low, high, count, count_low_high);
         start = stop + 1;

--- a/src/deleglise-rivat/S2_hard.cpp
+++ b/src/deleglise-rivat/S2_hard.cpp
@@ -109,7 +109,7 @@ T S2_hard_thread(T x,
         if (prime < factor.lpf(m))
         {
           int64_t fm = factor.get_number(m);
-          int64_t xn = fast_div<int64_t>(x2, fm);
+          int64_t xn = fast_div64(x2, fm);
           int64_t stop = xn - low;
           count += sieve.count(start, stop, low, high, count, count_low_high);
           start = stop + 1;
@@ -142,7 +142,7 @@ T S2_hard_thread(T x,
 
       for (; primes[l] > min_hard; l--)
       {
-        int64_t xn = fast_div<int64_t>(x2, primes[l]);
+        int64_t xn = fast_div64(x2, primes[l]);
         int64_t stop = xn - low;
         count += sieve.count(start, stop, low, high, count, count_low_high);
         start = stop + 1;

--- a/src/mpi/S2_easy_mpi.cpp
+++ b/src/mpi/S2_easy_mpi.cpp
@@ -76,9 +76,9 @@ T S2_easy_mpi_master(T x,
     // where phi(x / n, b - 1) = pi(x / n) - b + 2
     while (l > pi_min_clustered)
     {
-      int64_t xn = (int64_t) fast_div(x2, primes[l]);
+      int64_t xn = fast_div<int64_t>(x2, primes[l]);
       int64_t phi_xn = pi[xn] - b + 2;
-      int64_t xm = (int64_t) fast_div(x2, primes[b + phi_xn - 1]);
+      int64_t xm = fast_div<int64_t>(x2, primes[b + phi_xn - 1]);
       int64_t l2 = pi[xm];
       s2_easy += phi_xn * (l - l2);
       l = l2;
@@ -89,7 +89,7 @@ T S2_easy_mpi_master(T x,
     // x / n <= y && phi(x / n, b - 1) = pi(x / n) - b + 2
     for (; l > pi_min_sparse; l--)
     {
-      int64_t xn = (int64_t) fast_div(x2, primes[l]);
+      int64_t xn = fast_div<int64_t>(x2, primes[l]);
       s2_easy += pi[xn] - b + 2;
     }
 

--- a/src/mpi/S2_easy_mpi.cpp
+++ b/src/mpi/S2_easy_mpi.cpp
@@ -76,9 +76,9 @@ T S2_easy_mpi_master(T x,
     // where phi(x / n, b - 1) = pi(x / n) - b + 2
     while (l > pi_min_clustered)
     {
-      int64_t xn = fast_div<int64_t>(x2, primes[l]);
+      int64_t xn = fast_div64(x2, primes[l]);
       int64_t phi_xn = pi[xn] - b + 2;
-      int64_t xm = fast_div<int64_t>(x2, primes[b + phi_xn - 1]);
+      int64_t xm = fast_div64(x2, primes[b + phi_xn - 1]);
       int64_t l2 = pi[xm];
       s2_easy += phi_xn * (l - l2);
       l = l2;
@@ -89,7 +89,7 @@ T S2_easy_mpi_master(T x,
     // x / n <= y && phi(x / n, b - 1) = pi(x / n) - b + 2
     for (; l > pi_min_sparse; l--)
     {
-      int64_t xn = fast_div<int64_t>(x2, primes[l]);
+      int64_t xn = fast_div64(x2, primes[l]);
       s2_easy += pi[xn] - b + 2;
     }
 

--- a/src/mpi/S2_easy_mpi_libdivide.cpp
+++ b/src/mpi/S2_easy_mpi_libdivide.cpp
@@ -5,7 +5,7 @@
 ///        divides with comparatively cheap multiplication and
 ///        bitshifts.
 ///
-/// Copyright (C) 2018 Kim Walisch, <kim.walisch@gmail.com>
+/// Copyright (C) 2019 Kim Walisch, <kim.walisch@gmail.com>
 ///
 /// This file is distributed under the BSD License. See the COPYING
 /// file in the top level directory.
@@ -13,6 +13,7 @@
 
 #include <PiTable.hpp>
 #include <primecount-internal.hpp>
+#include <fast_div.hpp>
 #include <generate.hpp>
 #include <int128_t.hpp>
 #include <min.hpp>
@@ -120,9 +121,9 @@ T S2_easy_mpi_master(T x,
       // where phi(x / n, b - 1) = pi(x / n) - b + 2
       while (l > pi_min_clustered)
       {
-        int64_t xn = (int64_t) (x2 / primes[l]);
+        int64_t xn = fast_div64(x2, primes[l]);
         int64_t phi_xn = pi[xn] - b + 2;
-        int64_t xm = (int64_t) (x2 / primes[b + phi_xn - 1]);
+        int64_t xm = fast_div64(x2, primes[b + phi_xn - 1]);
         int64_t l2 = pi[xm];
         s2_easy += phi_xn * (l - l2);
         l = l2;
@@ -133,7 +134,7 @@ T S2_easy_mpi_master(T x,
       // x / n <= y && phi(x / n, b - 1) = pi(x / n) - b + 2
       for (; l > pi_min_sparse; l--)
       {
-        int64_t xn = (int64_t) (x2 / primes[l]);
+        int64_t xn = fast_div64(x2, primes[l]);
         s2_easy += pi[xn] - b + 2;
       }
     }

--- a/src/mpi/S2_hard_mpi.cpp
+++ b/src/mpi/S2_hard_mpi.cpp
@@ -112,7 +112,7 @@ T S2_hard_thread(T x,
         if (prime < factor.lpf(m))
         {
           int64_t fm = factor.get_number(m);
-          int64_t xn = (int64_t) fast_div(x2, fm);
+          int64_t xn = fast_div<int64_t>(x2, fm);
           int64_t stop = xn - low;
           count += sieve.count(start, stop, low, high, count, count_low_high);
           start = stop + 1;
@@ -145,7 +145,7 @@ T S2_hard_thread(T x,
 
       for (; primes[l] > min_hard; l--)
       {
-        int64_t xn = (int64_t) fast_div(x2, primes[l]);
+        int64_t xn = fast_div<int64_t>(x2, primes[l]);
         int64_t stop = xn - low;
         count += sieve.count(start, stop, low, high, count, count_low_high);
         start = stop + 1;

--- a/src/mpi/S2_hard_mpi.cpp
+++ b/src/mpi/S2_hard_mpi.cpp
@@ -112,7 +112,7 @@ T S2_hard_thread(T x,
         if (prime < factor.lpf(m))
         {
           int64_t fm = factor.get_number(m);
-          int64_t xn = fast_div<int64_t>(x2, fm);
+          int64_t xn = fast_div64(x2, fm);
           int64_t stop = xn - low;
           count += sieve.count(start, stop, low, high, count, count_low_high);
           start = stop + 1;
@@ -145,7 +145,7 @@ T S2_hard_thread(T x,
 
       for (; primes[l] > min_hard; l--)
       {
-        int64_t xn = fast_div<int64_t>(x2, primes[l]);
+        int64_t xn = fast_div64(x2, primes[l]);
         int64_t stop = xn - low;
         count += sieve.count(start, stop, low, high, count, count_low_high);
         start = stop + 1;


### PR DESCRIPTION
If ```n``` is some 128-bit numerator and ```d``` is some 64-bit divider and we know that the result of ```n / d``` will fit into 64-bit we can use the x64 ```divq``` instruction instead of doing a full 128-bit division.

```C++
/// Optimized (128-bit / 64-bit) = 64-bit, for x64.
/// uint64_t fast_div64(uint128_t x, uint64_t x)
template <typename X, typename Y>
typename std::enable_if<(sizeof(X) == sizeof(uint64_t) * 2 &&
                         sizeof(Y) <= sizeof(uint64_t)), uint64_t>::type
fast_div64(X x, Y y)
{
#if defined(__x86_64__) && \
   (defined(__GNUC__) || defined(__clang__))

  // primecount does not need signed division so 
  // we use the unsigned division instruction further
  // down as DIV is usually faster than IDIV.
  assert(x >= 0 && y > 0);

  uint64_t result;
  uint64_t remainder;
  uint64_t x0 = (uint64_t) x;
  uint64_t x1 = ((uint64_t*) &x)[1];
  uint64_t d = y;

  // We know the result is 64-bit (even though the
  // numerator is 128-bit) so we can use the divq
  // instruction instead of doing a full 128-bit division.
  __asm__("divq %[divider]"
          : "=a"(result), "=d"(remainder)
          : "a"(x0), "d"(x1), [divider] "r"(d)
          );

  return result;
#else
  return (uint64_t) fast_div(x, y);
#endif
}
```