### PR TITLE
Avoid calling vector's operator[] with an out-of-bounds index.

### DIFF
--- a/src/Sieve.cpp
+++ b/src/Sieve.cpp
@@ -211,31 +211,31 @@ void Sieve::cross_off(uint64_t prime, uint64_t i)
   {
     // pointer to the byte with the 1st multiple 
     byte_t* s = &sieve_[wheel.multiple];
-    byte_t* sieve_end = &sieve_[sieve_size];
+    byte_t* sieve_end = &sieve_[sieve_size - 1U];
     prime /= 30;
 
     switch (wheel.index)
     {
       for (;;)
       {
-        if (s >= sieve_end) { wheel.index = 0; break; }
+        if (s > sieve_end) { wheel.index = 0; break; }
         case 0: unset_bit<0>(s); s += prime * 6 + 0;
-        if (s >= sieve_end) { wheel.index = 1; break; }
+        if (s > sieve_end) { wheel.index = 1; break; }
         case 1: unset_bit<1>(s); s += prime * 4 + 0;
-        if (s >= sieve_end) { wheel.index = 2; break; }
+        if (s > sieve_end) { wheel.index = 2; break; }
         case 2: unset_bit<2>(s); s += prime * 2 + 0;
-        if (s >= sieve_end) { wheel.index = 3; break; }
+        if (s > sieve_end) { wheel.index = 3; break; }
         case 3: unset_bit<3>(s); s += prime * 4 + 0;
-        if (s >= sieve_end) { wheel.index = 4; break; }
+        if (s > sieve_end) { wheel.index = 4; break; }
         case 4: unset_bit<4>(s); s += prime * 2 + 0;
-        if (s >= sieve_end) { wheel.index = 5; break; }
+        if (s > sieve_end) { wheel.index = 5; break; }
         case 5: unset_bit<5>(s); s += prime * 4 + 0;
-        if (s >= sieve_end) { wheel.index = 6; break; }
+        if (s > sieve_end) { wheel.index = 6; break; }
         case 6: unset_bit<6>(s); s += prime * 6 + 0;
-        if (s >= sieve_end) { wheel.index = 7; break; }
+        if (s > sieve_end) { wheel.index = 7; break; }
         case 7: unset_bit<7>(s); s += prime * 2 + 1;
 
-        while (s + prime * 28 < sieve_end)
+        while (s + prime * 28 <= sieve_end)
         {
           unset_bit<0>(s + prime *  0);
           unset_bit<1>(s + prime *  6);
@@ -252,24 +252,24 @@ void Sieve::cross_off(uint64_t prime, uint64_t i)
 
       for (;;)
       {
-        if (s >= sieve_end) { wheel.index =  8; break; }
+        if (s > sieve_end) { wheel.index =  8; break; }
         case  8: unset_bit<1>(s); s += prime * 6 + 1;
-        if (s >= sieve_end) { wheel.index =  9; break; }
+        if (s > sieve_end) { wheel.index =  9; break; }
         case  9: unset_bit<5>(s); s += prime * 4 + 1;
-        if (s >= sieve_end) { wheel.index = 10; break; }
+        if (s > sieve_end) { wheel.index = 10; break; }
         case 10: unset_bit<4>(s); s += prime * 2 + 1;
-        if (s >= sieve_end) { wheel.index = 11; break; }
+        if (s > sieve_end) { wheel.index = 11; break; }
         case 11: unset_bit<0>(s); s += prime * 4 + 0;
-        if (s >= sieve_end) { wheel.index = 12; break; }
+        if (s > sieve_end) { wheel.index = 12; break; }
         case 12: unset_bit<7>(s); s += prime * 2 + 1;
-        if (s >= sieve_end) { wheel.index = 13; break; }
+        if (s > sieve_end) { wheel.index = 13; break; }
         case 13: unset_bit<3>(s); s += prime * 4 + 1;
-        if (s >= sieve_end) { wheel.index = 14; break; }
+        if (s > sieve_end) { wheel.index = 14; break; }
         case 14: unset_bit<2>(s); s += prime * 6 + 1;
-        if (s >= sieve_end) { wheel.index = 15; break; }
+        if (s > sieve_end) { wheel.index = 15; break; }
         case 15: unset_bit<6>(s); s += prime * 2 + 1;
 
-        while (s + prime * 28 + 6 < sieve_end)
+        while (s + prime * 28 + 6 <= sieve_end)
         {
           unset_bit<1>(s + prime *  0 + 0);
           unset_bit<5>(s + prime *  6 + 1);
@@ -286,24 +286,24 @@ void Sieve::cross_off(uint64_t prime, uint64_t i)
 
       for (;;)
       {
-        if (s >= sieve_end) { wheel.index = 16; break; }
+        if (s > sieve_end) { wheel.index = 16; break; }
         case 16: unset_bit<2>(s); s += prime * 6 + 2;
-        if (s >= sieve_end) { wheel.index = 17; break; }
+        if (s > sieve_end) { wheel.index = 17; break; }
         case 17: unset_bit<4>(s); s += prime * 4 + 2;
-        if (s >= sieve_end) { wheel.index = 18; break; }
+        if (s > sieve_end) { wheel.index = 18; break; }
         case 18: unset_bit<0>(s); s += prime * 2 + 0;
-        if (s >= sieve_end) { wheel.index = 19; break; }
+        if (s > sieve_end) { wheel.index = 19; break; }
         case 19: unset_bit<6>(s); s += prime * 4 + 2;
-        if (s >= sieve_end) { wheel.index = 20; break; }
+        if (s > sieve_end) { wheel.index = 20; break; }
         case 20: unset_bit<1>(s); s += prime * 2 + 0;
-        if (s >= sieve_end) { wheel.index = 21; break; }
+        if (s > sieve_end) { wheel.index = 21; break; }
         case 21: unset_bit<7>(s); s += prime * 4 + 2;
-        if (s >= sieve_end) { wheel.index = 22; break; }
+        if (s > sieve_end) { wheel.index = 22; break; }
         case 22: unset_bit<3>(s); s += prime * 6 + 2;
-        if (s >= sieve_end) { wheel.index = 23; break; }
+        if (s > sieve_end) { wheel.index = 23; break; }
         case 23: unset_bit<5>(s); s += prime * 2 + 1;
 
-        while (s + prime * 28 + 10 < sieve_end)
+        while (s + prime * 28 + 10 <= sieve_end)
         {
           unset_bit<2>(s + prime *  0 +  0);
           unset_bit<4>(s + prime *  6 +  2);
@@ -320,24 +320,24 @@ void Sieve::cross_off(uint64_t prime, uint64_t i)
 
       for (;;)
       {
-        if (s >= sieve_end) { wheel.index = 24; break; }
+        if (s > sieve_end) { wheel.index = 24; break; }
         case 24: unset_bit<3>(s); s += prime * 6 + 3;
-        if (s >= sieve_end) { wheel.index = 25; break; }
+        if (s > sieve_end) { wheel.index = 25; break; }
         case 25: unset_bit<0>(s); s += prime * 4 + 1;
-        if (s >= sieve_end) { wheel.index = 26; break; }
+        if (s > sieve_end) { wheel.index = 26; break; }
         case 26: unset_bit<6>(s); s += prime * 2 + 1;
-        if (s >= sieve_end) { wheel.index = 27; break; }
+        if (s > sieve_end) { wheel.index = 27; break; }
         case 27: unset_bit<5>(s); s += prime * 4 + 2;
-        if (s >= sieve_end) { wheel.index = 28; break; }
+        if (s > sieve_end) { wheel.index = 28; break; }
         case 28: unset_bit<2>(s); s += prime * 2 + 1;
-        if (s >= sieve_end) { wheel.index = 29; break; }
+        if (s > sieve_end) { wheel.index = 29; break; }
         case 29: unset_bit<1>(s); s += prime * 4 + 1;
-        if (s >= sieve_end) { wheel.index = 30; break; }
+        if (s > sieve_end) { wheel.index = 30; break; }
         case 30: unset_bit<7>(s); s += prime * 6 + 3;
-        if (s >= sieve_end) { wheel.index = 31; break; }
+        if (s > sieve_end) { wheel.index = 31; break; }
         case 31: unset_bit<4>(s); s += prime * 2 + 1;
 
-        while (s + prime * 28 + 12 < sieve_end)
+        while (s + prime * 28 + 12 <= sieve_end)
         {
           unset_bit<3>(s + prime *  0 +  0);
           unset_bit<0>(s + prime *  6 +  3);
@@ -354,24 +354,24 @@ void Sieve::cross_off(uint64_t prime, uint64_t i)
 
       for (;;)
       {
-        if (s >= sieve_end) { wheel.index = 32; break; }
+        if (s > sieve_end) { wheel.index = 32; break; }
         case 32: unset_bit<4>(s); s += prime * 6 + 3;
-        if (s >= sieve_end) { wheel.index = 33; break; }
+        if (s > sieve_end) { wheel.index = 33; break; }
         case 33: unset_bit<7>(s); s += prime * 4 + 3;
-        if (s >= sieve_end) { wheel.index = 34; break; }
+        if (s > sieve_end) { wheel.index = 34; break; }
         case 34: unset_bit<1>(s); s += prime * 2 + 1;
-        if (s >= sieve_end) { wheel.index = 35; break; }
+        if (s > sieve_end) { wheel.index = 35; break; }
         case 35: unset_bit<2>(s); s += prime * 4 + 2;
-        if (s >= sieve_end) { wheel.index = 36; break; }
+        if (s > sieve_end) { wheel.index = 36; break; }
         case 36: unset_bit<5>(s); s += prime * 2 + 1;
-        if (s >= sieve_end) { wheel.index = 37; break; }
+        if (s > sieve_end) { wheel.index = 37; break; }
         case 37: unset_bit<6>(s); s += prime * 4 + 3;
-        if (s >= sieve_end) { wheel.index = 38; break; }
+        if (s > sieve_end) { wheel.index = 38; break; }
         case 38: unset_bit<0>(s); s += prime * 6 + 3;
-        if (s >= sieve_end) { wheel.index = 39; break; }
+        if (s > sieve_end) { wheel.index = 39; break; }
         case 39: unset_bit<3>(s); s += prime * 2 + 1;
 
-        while (s + prime * 28 + 16 < sieve_end)
+        while (s + prime * 28 + 16 <= sieve_end)
         {
           unset_bit<4>(s + prime *  0 +  0);
           unset_bit<7>(s + prime *  6 +  3);
@@ -388,24 +388,24 @@ void Sieve::cross_off(uint64_t prime, uint64_t i)
 
       for (;;)
       {
-        if (s >= sieve_end) { wheel.index = 40; break; }
+        if (s > sieve_end) { wheel.index = 40; break; }
         case 40: unset_bit<5>(s); s += prime * 6 + 4;
-        if (s >= sieve_end) { wheel.index = 41; break; }
+        if (s > sieve_end) { wheel.index = 41; break; }
         case 41: unset_bit<3>(s); s += prime * 4 + 2;
-        if (s >= sieve_end) { wheel.index = 42; break; }
+        if (s > sieve_end) { wheel.index = 42; break; }
         case 42: unset_bit<7>(s); s += prime * 2 + 2;
-        if (s >= sieve_end) { wheel.index = 43; break; }
+        if (s > sieve_end) { wheel.index = 43; break; }
         case 43: unset_bit<1>(s); s += prime * 4 + 2;
-        if (s >= sieve_end) { wheel.index = 44; break; }
+        if (s > sieve_end) { wheel.index = 44; break; }
         case 44: unset_bit<6>(s); s += prime * 2 + 2;
-        if (s >= sieve_end) { wheel.index = 45; break; }
+        if (s > sieve_end) { wheel.index = 45; break; }
         case 45: unset_bit<0>(s); s += prime * 4 + 2;
-        if (s >= sieve_end) { wheel.index = 46; break; }
+        if (s > sieve_end) { wheel.index = 46; break; }
         case 46: unset_bit<4>(s); s += prime * 6 + 4;
-        if (s >= sieve_end) { wheel.index = 47; break; }
+        if (s > sieve_end) { wheel.index = 47; break; }
         case 47: unset_bit<2>(s); s += prime * 2 + 1;
 
-        while (s + prime * 28 + 18 < sieve_end)
+        while (s + prime * 28 + 18 <= sieve_end)
         {
           unset_bit<5>(s + prime *  0 +  0);
           unset_bit<3>(s + prime *  6 +  4);
@@ -422,24 +422,24 @@ void Sieve::cross_off(uint64_t prime, uint64_t i)
 
       for (;;)
       {
-        if (s >= sieve_end) { wheel.index = 48; break; }
+        if (s > sieve_end) { wheel.index = 48; break; }
         case 48: unset_bit<6>(s); s += prime * 6 + 5;
-        if (s >= sieve_end) { wheel.index = 49; break; }
+        if (s > sieve_end) { wheel.index = 49; break; }
         case 49: unset_bit<2>(s); s += prime * 4 + 3;
-        if (s >= sieve_end) { wheel.index = 50; break; }
+        if (s > sieve_end) { wheel.index = 50; break; }
         case 50: unset_bit<3>(s); s += prime * 2 + 1;
-        if (s >= sieve_end) { wheel.index = 51; break; }
+        if (s > sieve_end) { wheel.index = 51; break; }
         case 51: unset_bit<7>(s); s += prime * 4 + 4;
-        if (s >= sieve_end) { wheel.index = 52; break; }
+        if (s > sieve_end) { wheel.index = 52; break; }
         case 52: unset_bit<0>(s); s += prime * 2 + 1;
-        if (s >= sieve_end) { wheel.index = 53; break; }
+        if (s > sieve_end) { wheel.index = 53; break; }
         case 53: unset_bit<4>(s); s += prime * 4 + 3;
-        if (s >= sieve_end) { wheel.index = 54; break; }
+        if (s > sieve_end) { wheel.index = 54; break; }
         case 54: unset_bit<5>(s); s += prime * 6 + 5;
-        if (s >= sieve_end) { wheel.index = 55; break; }
+        if (s > sieve_end) { wheel.index = 55; break; }
         case 55: unset_bit<1>(s); s += prime * 2 + 1;
 
-        while (s + prime * 28 + 22 < sieve_end)
+        while (s + prime * 28 + 22 <= sieve_end)
         {
           unset_bit<6>(s + prime *  0 +  0);
           unset_bit<2>(s + prime *  6 +  5);
@@ -456,24 +456,24 @@ void Sieve::cross_off(uint64_t prime, uint64_t i)
 
       for (;;)
       {
-        if (s >= sieve_end) { wheel.index = 56; break; }
+        if (s > sieve_end) { wheel.index = 56; break; }
         case 56: unset_bit<7>(s); s += prime * 6 + 6;
-        if (s >= sieve_end) { wheel.index = 57; break; }
+        if (s > sieve_end) { wheel.index = 57; break; }
         case 57: unset_bit<6>(s); s += prime * 4 + 4;
-        if (s >= sieve_end) { wheel.index = 58; break; }
+        if (s > sieve_end) { wheel.index = 58; break; }
         case 58: unset_bit<5>(s); s += prime * 2 + 2;
-        if (s >= sieve_end) { wheel.index = 59; break; }
+        if (s > sieve_end) { wheel.index = 59; break; }
         case 59: unset_bit<4>(s); s += prime * 4 + 4;
-        if (s >= sieve_end) { wheel.index = 60; break; }
+        if (s > sieve_end) { wheel.index = 60; break; }
         case 60: unset_bit<3>(s); s += prime * 2 + 2;
-        if (s >= sieve_end) { wheel.index = 61; break; }
+        if (s > sieve_end) { wheel.index = 61; break; }
         case 61: unset_bit<2>(s); s += prime * 4 + 4;
-        if (s >= sieve_end) { wheel.index = 62; break; }
+        if (s > sieve_end) { wheel.index = 62; break; }
         case 62: unset_bit<1>(s); s += prime * 6 + 6;
-        if (s >= sieve_end) { wheel.index = 63; break; }
+        if (s > sieve_end) { wheel.index = 63; break; }
         case 63: unset_bit<0>(s); s += prime * 2 + 1;
 
-        while (s + prime * 28 + 28 < sieve_end)
+        while (s + prime * 28 + 28 <= sieve_end)
         {
           unset_bit<7>(s + prime *  0 +  0);
           unset_bit<6>(s + prime *  6 +  6);
@@ -490,7 +490,7 @@ void Sieve::cross_off(uint64_t prime, uint64_t i)
     }
 
     // update for the next segment
-    wheel.multiple = (uint32_t) (s - sieve_end);
+    wheel.multiple = (uint32_t) (s - sieve_end - 1U);
   }
 }
 
@@ -515,31 +515,31 @@ uint64_t Sieve::cross_off_count(uint64_t prime, uint64_t i)
   {
     // pointer to the byte with the 1st multiple 
     byte_t* s = &sieve_[wheel.multiple];
-    byte_t* sieve_end = &sieve_[sieve_size];
+    byte_t* sieve_end = &sieve_[sieve_size - 1U];
     prime /= 30;
 
     switch (wheel.index)
     {
       for (;;)
       {
-        if (s >= sieve_end) { wheel.index = 0; break; }
+        if (s > sieve_end) { wheel.index = 0; break; }
         case 0: cnt += is_bit<0>(s); unset_bit<0>(s); s += prime * 6 + 0;
-        if (s >= sieve_end) { wheel.index = 1; break; }
+        if (s > sieve_end) { wheel.index = 1; break; }
         case 1: cnt += is_bit<1>(s); unset_bit<1>(s); s += prime * 4 + 0;
-        if (s >= sieve_end) { wheel.index = 2; break; }
+        if (s > sieve_end) { wheel.index = 2; break; }
         case 2: cnt += is_bit<2>(s); unset_bit<2>(s); s += prime * 2 + 0;
-        if (s >= sieve_end) { wheel.index = 3; break; }
+        if (s > sieve_end) { wheel.index = 3; break; }
         case 3: cnt += is_bit<3>(s); unset_bit<3>(s); s += prime * 4 + 0;
-        if (s >= sieve_end) { wheel.index = 4; break; }
+        if (s > sieve_end) { wheel.index = 4; break; }
         case 4: cnt += is_bit<4>(s); unset_bit<4>(s); s += prime * 2 + 0;
-        if (s >= sieve_end) { wheel.index = 5; break; }
+        if (s > sieve_end) { wheel.index = 5; break; }
         case 5: cnt += is_bit<5>(s); unset_bit<5>(s); s += prime * 4 + 0;
-        if (s >= sieve_end) { wheel.index = 6; break; }
+        if (s > sieve_end) { wheel.index = 6; break; }
         case 6: cnt += is_bit<6>(s); unset_bit<6>(s); s += prime * 6 + 0;
-        if (s >= sieve_end) { wheel.index = 7; break; }
+        if (s > sieve_end) { wheel.index = 7; break; }
         case 7: cnt += is_bit<7>(s); unset_bit<7>(s); s += prime * 2 + 1;
 
-        while (s + prime * 28 < sieve_end)
+        while (s + prime * 28 <= sieve_end)
         {
           cnt += is_bit<0>(s + prime *  0);
           unset_bit<0>(s + prime *  0);
@@ -564,24 +564,24 @@ uint64_t Sieve::cross_off_count(uint64_t prime, uint64_t i)
 
       for (;;)
       {
-        if (s >= sieve_end) { wheel.index =  8; break; }
+        if (s > sieve_end) { wheel.index =  8; break; }
         case  8: cnt += is_bit<1>(s); unset_bit<1>(s); s += prime * 6 + 1;
-        if (s >= sieve_end) { wheel.index =  9; break; }
+        if (s > sieve_end) { wheel.index =  9; break; }
         case  9: cnt += is_bit<5>(s); unset_bit<5>(s); s += prime * 4 + 1;
-        if (s >= sieve_end) { wheel.index = 10; break; }
+        if (s > sieve_end) { wheel.index = 10; break; }
         case 10: cnt += is_bit<4>(s); unset_bit<4>(s); s += prime * 2 + 1;
-        if (s >= sieve_end) { wheel.index = 11; break; }
+        if (s > sieve_end) { wheel.index = 11; break; }
         case 11: cnt += is_bit<0>(s); unset_bit<0>(s); s += prime * 4 + 0;
-        if (s >= sieve_end) { wheel.index = 12; break; }
+        if (s > sieve_end) { wheel.index = 12; break; }
         case 12: cnt += is_bit<7>(s); unset_bit<7>(s); s += prime * 2 + 1;
-        if (s >= sieve_end) { wheel.index = 13; break; }
+        if (s > sieve_end) { wheel.index = 13; break; }
         case 13: cnt += is_bit<3>(s); unset_bit<3>(s); s += prime * 4 + 1;
-        if (s >= sieve_end) { wheel.index = 14; break; }
+        if (s > sieve_end) { wheel.index = 14; break; }
         case 14: cnt += is_bit<2>(s); unset_bit<2>(s); s += prime * 6 + 1;
-        if (s >= sieve_end) { wheel.index = 15; break; }
+        if (s > sieve_end) { wheel.index = 15; break; }
         case 15: cnt += is_bit<6>(s); unset_bit<6>(s); s += prime * 2 + 1;
 
-        while (s + prime * 28 + 6 < sieve_end)
+        while (s + prime * 28 + 6 <= sieve_end)
         {
           cnt += is_bit<1>(s + prime *  0 + 0);
           unset_bit<1>(s + prime *  0 + 0);
@@ -606,24 +606,24 @@ uint64_t Sieve::cross_off_count(uint64_t prime, uint64_t i)
 
       for (;;)
       {
-        if (s >= sieve_end) { wheel.index = 16; break; }
+        if (s > sieve_end) { wheel.index = 16; break; }
         case 16: cnt += is_bit<2>(s); unset_bit<2>(s); s += prime * 6 + 2;
-        if (s >= sieve_end) { wheel.index = 17; break; }
+        if (s > sieve_end) { wheel.index = 17; break; }
         case 17: cnt += is_bit<4>(s); unset_bit<4>(s); s += prime * 4 + 2;
-        if (s >= sieve_end) { wheel.index = 18; break; }
+        if (s > sieve_end) { wheel.index = 18; break; }
         case 18: cnt += is_bit<0>(s); unset_bit<0>(s); s += prime * 2 + 0;
-        if (s >= sieve_end) { wheel.index = 19; break; }
+        if (s > sieve_end) { wheel.index = 19; break; }
         case 19: cnt += is_bit<6>(s); unset_bit<6>(s); s += prime * 4 + 2;
-        if (s >= sieve_end) { wheel.index = 20; break; }
+        if (s > sieve_end) { wheel.index = 20; break; }
         case 20: cnt += is_bit<1>(s); unset_bit<1>(s); s += prime * 2 + 0;
-        if (s >= sieve_end) { wheel.index = 21; break; }
+        if (s > sieve_end) { wheel.index = 21; break; }
         case 21: cnt += is_bit<7>(s); unset_bit<7>(s); s += prime * 4 + 2;
-        if (s >= sieve_end) { wheel.index = 22; break; }
+        if (s > sieve_end) { wheel.index = 22; break; }
         case 22: cnt += is_bit<3>(s); unset_bit<3>(s); s += prime * 6 + 2;
-        if (s >= sieve_end) { wheel.index = 23; break; }
+        if (s > sieve_end) { wheel.index = 23; break; }
         case 23: cnt += is_bit<5>(s); unset_bit<5>(s); s += prime * 2 + 1;
 
-        while (s + prime * 28 + 10 < sieve_end)
+        while (s + prime * 28 + 10 <= sieve_end)
         {
           cnt += is_bit<2>(s + prime *  0 +  0);
           unset_bit<2>(s + prime *  0 +  0);
@@ -648,24 +648,24 @@ uint64_t Sieve::cross_off_count(uint64_t prime, uint64_t i)
 
       for (;;)
       {
-        if (s >= sieve_end) { wheel.index = 24; break; }
+        if (s > sieve_end) { wheel.index = 24; break; }
         case 24: cnt += is_bit<3>(s); unset_bit<3>(s); s += prime * 6 + 3;
-        if (s >= sieve_end) { wheel.index = 25; break; }
+        if (s > sieve_end) { wheel.index = 25; break; }
         case 25: cnt += is_bit<0>(s); unset_bit<0>(s); s += prime * 4 + 1;
-        if (s >= sieve_end) { wheel.index = 26; break; }
+        if (s > sieve_end) { wheel.index = 26; break; }
         case 26: cnt += is_bit<6>(s); unset_bit<6>(s); s += prime * 2 + 1;
-        if (s >= sieve_end) { wheel.index = 27; break; }
+        if (s > sieve_end) { wheel.index = 27; break; }
         case 27: cnt += is_bit<5>(s); unset_bit<5>(s); s += prime * 4 + 2;
-        if (s >= sieve_end) { wheel.index = 28; break; }
+        if (s > sieve_end) { wheel.index = 28; break; }
         case 28: cnt += is_bit<2>(s); unset_bit<2>(s); s += prime * 2 + 1;
-        if (s >= sieve_end) { wheel.index = 29; break; }
+        if (s > sieve_end) { wheel.index = 29; break; }
         case 29: cnt += is_bit<1>(s); unset_bit<1>(s); s += prime * 4 + 1;
-        if (s >= sieve_end) { wheel.index = 30; break; }
+        if (s > sieve_end) { wheel.index = 30; break; }
         case 30: cnt += is_bit<7>(s); unset_bit<7>(s); s += prime * 6 + 3;
-        if (s >= sieve_end) { wheel.index = 31; break; }
+        if (s > sieve_end) { wheel.index = 31; break; }
         case 31: cnt += is_bit<4>(s); unset_bit<4>(s); s += prime * 2 + 1;
 
-        while (s + prime * 28 + 12 < sieve_end)
+        while (s + prime * 28 + 12 <= sieve_end)
         {
           cnt += is_bit<3>(s + prime *  0 +  0);
           unset_bit<3>(s + prime *  0 +  0);
@@ -690,24 +690,24 @@ uint64_t Sieve::cross_off_count(uint64_t prime, uint64_t i)
 
       for (;;)
       {
-        if (s >= sieve_end) { wheel.index = 32; break; }
+        if (s > sieve_end) { wheel.index = 32; break; }
         case 32: cnt += is_bit<4>(s); unset_bit<4>(s); s += prime * 6 + 3;
-        if (s >= sieve_end) { wheel.index = 33; break; }
+        if (s > sieve_end) { wheel.index = 33; break; }
         case 33: cnt += is_bit<7>(s); unset_bit<7>(s); s += prime * 4 + 3;
-        if (s >= sieve_end) { wheel.index = 34; break; }
+        if (s > sieve_end) { wheel.index = 34; break; }
         case 34: cnt += is_bit<1>(s); unset_bit<1>(s); s += prime * 2 + 1;
-        if (s >= sieve_end) { wheel.index = 35; break; }
+        if (s > sieve_end) { wheel.index = 35; break; }
         case 35: cnt += is_bit<2>(s); unset_bit<2>(s); s += prime * 4 + 2;
-        if (s >= sieve_end) { wheel.index = 36; break; }
+        if (s > sieve_end) { wheel.index = 36; break; }
         case 36: cnt += is_bit<5>(s); unset_bit<5>(s); s += prime * 2 + 1;
-        if (s >= sieve_end) { wheel.index = 37; break; }
+        if (s > sieve_end) { wheel.index = 37; break; }
         case 37: cnt += is_bit<6>(s); unset_bit<6>(s); s += prime * 4 + 3;
-        if (s >= sieve_end) { wheel.index = 38; break; }
+        if (s > sieve_end) { wheel.index = 38; break; }
         case 38: cnt += is_bit<0>(s); unset_bit<0>(s); s += prime * 6 + 3;
-        if (s >= sieve_end) { wheel.index = 39; break; }
+        if (s > sieve_end) { wheel.index = 39; break; }
         case 39: cnt += is_bit<3>(s); unset_bit<3>(s); s += prime * 2 + 1;
 
-        while (s + prime * 28 + 16 < sieve_end)
+        while (s + prime * 28 + 16 <= sieve_end)
         {
           cnt += is_bit<4>(s + prime *  0 +  0);
           unset_bit<4>(s + prime *  0 +  0);
@@ -732,24 +732,24 @@ uint64_t Sieve::cross_off_count(uint64_t prime, uint64_t i)
 
       for (;;)
       {
-        if (s >= sieve_end) { wheel.index = 40; break; }
+        if (s > sieve_end) { wheel.index = 40; break; }
         case 40: cnt += is_bit<5>(s); unset_bit<5>(s); s += prime * 6 + 4;
-        if (s >= sieve_end) { wheel.index = 41; break; }
+        if (s > sieve_end) { wheel.index = 41; break; }
         case 41: cnt += is_bit<3>(s); unset_bit<3>(s); s += prime * 4 + 2;
-        if (s >= sieve_end) { wheel.index = 42; break; }
+        if (s > sieve_end) { wheel.index = 42; break; }
         case 42: cnt += is_bit<7>(s); unset_bit<7>(s); s += prime * 2 + 2;
-        if (s >= sieve_end) { wheel.index = 43; break; }
+        if (s > sieve_end) { wheel.index = 43; break; }
         case 43: cnt += is_bit<1>(s); unset_bit<1>(s); s += prime * 4 + 2;
-        if (s >= sieve_end) { wheel.index = 44; break; }
+        if (s > sieve_end) { wheel.index = 44; break; }
         case 44: cnt += is_bit<6>(s); unset_bit<6>(s); s += prime * 2 + 2;
-        if (s >= sieve_end) { wheel.index = 45; break; }
+        if (s > sieve_end) { wheel.index = 45; break; }
         case 45: cnt += is_bit<0>(s); unset_bit<0>(s); s += prime * 4 + 2;
-        if (s >= sieve_end) { wheel.index = 46; break; }
+        if (s > sieve_end) { wheel.index = 46; break; }
         case 46: cnt += is_bit<4>(s); unset_bit<4>(s); s += prime * 6 + 4;
-        if (s >= sieve_end) { wheel.index = 47; break; }
+        if (s > sieve_end) { wheel.index = 47; break; }
         case 47: cnt += is_bit<2>(s); unset_bit<2>(s); s += prime * 2 + 1;
 
-        while (s + prime * 28 + 18 < sieve_end)
+        while (s + prime * 28 + 18 <= sieve_end)
         {
           cnt += is_bit<5>(s + prime *  0 +  0);
           unset_bit<5>(s + prime *  0 +  0);
@@ -774,24 +774,24 @@ uint64_t Sieve::cross_off_count(uint64_t prime, uint64_t i)
 
       for (;;)
       {
-        if (s >= sieve_end) { wheel.index = 48; break; }
+        if (s > sieve_end) { wheel.index = 48; break; }
         case 48: cnt += is_bit<6>(s); unset_bit<6>(s); s += prime * 6 + 5;
-        if (s >= sieve_end) { wheel.index = 49; break; }
+        if (s > sieve_end) { wheel.index = 49; break; }
         case 49: cnt += is_bit<2>(s); unset_bit<2>(s); s += prime * 4 + 3;
-        if (s >= sieve_end) { wheel.index = 50; break; }
+        if (s > sieve_end) { wheel.index = 50; break; }
         case 50: cnt += is_bit<3>(s); unset_bit<3>(s); s += prime * 2 + 1;
-        if (s >= sieve_end) { wheel.index = 51; break; }
+        if (s > sieve_end) { wheel.index = 51; break; }
         case 51: cnt += is_bit<7>(s); unset_bit<7>(s); s += prime * 4 + 4;
-        if (s >= sieve_end) { wheel.index = 52; break; }
+        if (s > sieve_end) { wheel.index = 52; break; }
         case 52: cnt += is_bit<0>(s); unset_bit<0>(s); s += prime * 2 + 1;
-        if (s >= sieve_end) { wheel.index = 53; break; }
+        if (s > sieve_end) { wheel.index = 53; break; }
         case 53: cnt += is_bit<4>(s); unset_bit<4>(s); s += prime * 4 + 3;
-        if (s >= sieve_end) { wheel.index = 54; break; }
+        if (s > sieve_end) { wheel.index = 54; break; }
         case 54: cnt += is_bit<5>(s); unset_bit<5>(s); s += prime * 6 + 5;
-        if (s >= sieve_end) { wheel.index = 55; break; }
+        if (s > sieve_end) { wheel.index = 55; break; }
         case 55: cnt += is_bit<1>(s); unset_bit<1>(s); s += prime * 2 + 1;
 
-        while (s + prime * 28 + 22 < sieve_end)
+        while (s + prime * 28 + 22 <= sieve_end)
         {
           cnt += is_bit<6>(s + prime *  0 +  0);
           unset_bit<6>(s + prime *  0 +  0);
@@ -816,24 +816,24 @@ uint64_t Sieve::cross_off_count(uint64_t prime, uint64_t i)
 
       for (;;)
       {
-        if (s >= sieve_end) { wheel.index = 56; break; }
+        if (s > sieve_end) { wheel.index = 56; break; }
         case 56: cnt += is_bit<7>(s); unset_bit<7>(s); s += prime * 6 + 6;
-        if (s >= sieve_end) { wheel.index = 57; break; }
+        if (s > sieve_end) { wheel.index = 57; break; }
         case 57: cnt += is_bit<6>(s); unset_bit<6>(s); s += prime * 4 + 4;
-        if (s >= sieve_end) { wheel.index = 58; break; }
+        if (s > sieve_end) { wheel.index = 58; break; }
         case 58: cnt += is_bit<5>(s); unset_bit<5>(s); s += prime * 2 + 2;
-        if (s >= sieve_end) { wheel.index = 59; break; }
+        if (s > sieve_end) { wheel.index = 59; break; }
         case 59: cnt += is_bit<4>(s); unset_bit<4>(s); s += prime * 4 + 4;
-        if (s >= sieve_end) { wheel.index = 60; break; }
+        if (s > sieve_end) { wheel.index = 60; break; }
         case 60: cnt += is_bit<3>(s); unset_bit<3>(s); s += prime * 2 + 2;
-        if (s >= sieve_end) { wheel.index = 61; break; }
+        if (s > sieve_end) { wheel.index = 61; break; }
         case 61: cnt += is_bit<2>(s); unset_bit<2>(s); s += prime * 4 + 4;
-        if (s >= sieve_end) { wheel.index = 62; break; }
+        if (s > sieve_end) { wheel.index = 62; break; }
         case 62: cnt += is_bit<1>(s); unset_bit<1>(s); s += prime * 6 + 6;
-        if (s >= sieve_end) { wheel.index = 63; break; }
+        if (s > sieve_end) { wheel.index = 63; break; }
         case 63: cnt += is_bit<0>(s); unset_bit<0>(s); s += prime * 2 + 1;
 
-        while (s + prime * 28 + 28 < sieve_end)
+        while (s + prime * 28 + 28 <= sieve_end)
         {
           cnt += is_bit<7>(s + prime *  0 +  0);
           unset_bit<7>(s + prime *  0 +  0);
@@ -858,7 +858,7 @@ uint64_t Sieve::cross_off_count(uint64_t prime, uint64_t i)
     }
 
     // update for the next segment
-    wheel.multiple = (uint32_t) (s - sieve_end);
+    wheel.multiple = (uint32_t) (s - sieve_end - 1U);
   }
 
   return cnt;


### PR DESCRIPTION
If primecount is built with GCC and -D_GLIBCXX_ASSERTIONS is in the build flags, then some tests fail:

```
The following tests FAILED:
	  8 - S2_hard_xy (Child aborted)
	 10 - S2_xy (Child aborted)
	 11 - alpha (Child aborted)
	 12 - alpha_y (Child aborted)
	 13 - alpha_z (Child aborted)
	 35 - sieve1 (Child aborted)
	 36 - sieve2 (Child aborted)
```

Running these tests from the command line shows an assertion failure, e.g. for S2_hard_xy:
```
S2_hard(4912, 16) = 0   OK
S2_hard(4913, 17) = 0/usr/include/c++/9/bits/stl_vector.h:1042: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](std::vector<_Tp, _Alloc>::size_type) [with _Tp = unsigned char; _Alloc = std::allocator<unsigned char>; std::vector<_Tp, _Alloc>::reference = unsigned char&; std::vector<_Tp, _Alloc>::size_type = long unsigned int]: Assertion '__builtin_expect(__n < this->size(), true)' failed.
```

The problem is this code, on lines 214 and 518 of src/Sieve.cpp:
```
    byte_t* sieve_end = &sieve_[sieve_size];
```

Since sieve_size is the number of elements in the vector, this code asks for the address of the element just beyond the end of the vector.  But GCC's implementation of operator[] for std::vector looks like this:
```
      reference
      operator[](size_type __n) _GLIBCXX_NOEXCEPT
      {
        __glibcxx_requires_subscript(__n);
        return *(this->_M_impl._M_start + __n);
      }
```

The `__glibcxx_requires_subscript` line is where the assertion failure happens.  There actually is a pointer dereference on the following line, so even if assertions are not enabled, this code dereferences a pointer that points beyond the vector.

This commit changes sieve_end to point to the last element, so that the dereference is valid, then adjusts all of the comparisons with sieve_end accordingly.  If sieve_size == 0, then the affected code is not executed.  With this change, all tests pass.