### PR TITLE
Improve OpenMP scaling by reusing threads

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,9 @@
-2020-08-15 Kim Walisch  <kim.walisch@gmail.com>
+2020-08-17 Kim Walisch  <kim.walisch@gmail.com>
 
+  * AC.cpp: Reduce thread creation & destruction overhead.
   * AC.cpp: Improve upper bound of C2 formula.
   * AC.cpp: Avoid branch inside hot loop of A formula.
+  * SegmentedPiTable.cpp: Reuse threads from AC.cpp.
   * Status.cpp: Avoid thread synchronization when printing in
     order to improve scaling of AC and S2_easy.
   * Status.cpp: Improve S2_hard & D status accuracy.

--- a/include/SegmentedPiTable.hpp
+++ b/include/SegmentedPiTable.hpp
@@ -86,7 +86,7 @@ public:
 
 private:
   void reset_pi(uint64_t start, uint64_t stop);
-  void init_next_segment(uint64_t pi_low);
+  void init_next_segment();
 
   struct PiData
   {
@@ -97,11 +97,10 @@ private:
   static const std::array<uint64_t, 128> unset_bits_;
   std::vector<PiData> pi_;
   uint64_t low_ = 0;
+  uint64_t pi_low_minus_1_ = 0;
   uint64_t high_;
   uint64_t max_high_;
   uint64_t segment_size_;
-  int threads_;
-  uint64_t pi_low_minus_1 = 0;
 };
 
 } // namespace

--- a/include/SegmentedPiTable.hpp
+++ b/include/SegmentedPiTable.hpp
@@ -68,9 +68,9 @@ public:
     return prime_count + bit_count;
   }
 
-  bool finished() const
+  bool has_next() const
   {
-    return low_ >= max_high_;
+    return low_ < max_high_;
   }
 
   int64_t low() const

--- a/include/SegmentedPiTable.hpp
+++ b/include/SegmentedPiTable.hpp
@@ -13,7 +13,7 @@
 ///        only (n / 8) bytes of memory and returns the number of
 ///        primes <= n in O(1) operations.
 ///
-/// Copyright (C) 2019 Kim Walisch, <kim.walisch@gmail.com>
+/// Copyright (C) 2020 Kim Walisch, <kim.walisch@gmail.com>
 ///
 /// This file is distributed under the BSD License. See the COPYING
 /// file in the top level directory.
@@ -23,6 +23,7 @@
 #define SEGMENTEDPITABLE_HPP
 
 #include <popcnt.hpp>
+#include <aligned_vector.hpp>
 
 #include <stdint.h>
 #include <array>
@@ -42,7 +43,8 @@ class SegmentedPiTable
 {
 public:
   SegmentedPiTable(uint64_t limit,
-                   uint64_t segment_size);
+                   uint64_t segment_size,
+                   int threads);
 
   void init();
   void next();
@@ -85,6 +87,7 @@ public:
 
 private:
   void reset_pi(uint64_t start, uint64_t stop);
+  void update_prime_count(uint64_t start, uint64_t stop, uint64_t thread_num);
 
   struct PiData
   {
@@ -94,11 +97,13 @@ private:
 
   static const std::array<uint64_t, 128> unset_bits_;
   std::vector<PiData> pi_;
+  aligned_vector<uint64_t> counts_;
   uint64_t low_ = 0;
-  uint64_t pi_low_minus_1_ = 0;
+  uint64_t pi_low_ = 0;
   uint64_t high_;
   uint64_t max_high_;
   uint64_t segment_size_;
+  int threads_;
 };
 
 } // namespace

--- a/include/SegmentedPiTable.hpp
+++ b/include/SegmentedPiTable.hpp
@@ -101,6 +101,7 @@ private:
   uint64_t max_high_;
   uint64_t segment_size_;
   int threads_;
+  uint64_t pi_low_minus_1 = 0;
 };
 
 } // namespace

--- a/include/SegmentedPiTable.hpp
+++ b/include/SegmentedPiTable.hpp
@@ -42,10 +42,9 @@ class SegmentedPiTable
 {
 public:
   SegmentedPiTable(uint64_t limit,
-                   uint64_t segment_size,
-                   int threads);
+                   uint64_t segment_size);
 
-  /// Increase low & high and initialize the next segment.
+  void init();
   void next();
 
   /// Get number of primes <= n
@@ -86,7 +85,6 @@ public:
 
 private:
   void reset_pi(uint64_t start, uint64_t stop);
-  void init_next_segment();
 
   struct PiData
   {

--- a/src/P2.cpp
+++ b/src/P2.cpp
@@ -12,7 +12,7 @@
 ///        method, Revista do DETUA, vol. 4, no. 6, March 2006,
 ///        pp. 759-768.
 ///
-/// Copyright (C) 2019 Kim Walisch, <kim.walisch@gmail.com>
+/// Copyright (C) 2020 Kim Walisch, <kim.walisch@gmail.com>
 ///
 /// This file is distributed under the BSD License. See the COPYING
 /// file in the top level directory.
@@ -32,6 +32,10 @@
 #include <iostream>
 #include <iomanip>
 #include <tuple>
+
+#ifdef _OPENMP
+  #include <omp.h>
+#endif
 
 using namespace std;
 using namespace primecount;
@@ -84,35 +88,36 @@ P2_thread(T x,
   T sum = 0;
   int64_t pix = 0;
   int64_t pix_count = 0;
-
-  // thread sieves [low, z[
   low += thread_distance * thread_num;
-  z = min(low + thread_distance, z);
-  int64_t start = (int64_t) max(x / z, y);
-  int64_t stop = (int64_t) min(x / low, isqrt(x));
 
-  primesieve::iterator rit(stop + 1, start);
-  primesieve::iterator it(low - 1, z);
-
-  int64_t next = it.next_prime();
-  int64_t prime = rit.prev_prime();
-
-  // \sum_{i = pi[start]+1}^{pi[stop]} pi(x / primes[i]) - pi(low - 1)
-  while (prime > start)
+  if (low < z)
   {
-    int64_t xp = (int64_t)(x / prime);
-    if (xp >= z) break;
-    pix += count_primes(it, next, xp);
-    pix_count++;
-    sum += pix;
-    prime = rit.prev_prime();
+    // thread sieves [low, z[
+    z = min(low + thread_distance, z);
+    int64_t start = (int64_t) max(x / z, y);
+    int64_t stop = (int64_t) min(x / low, isqrt(x));
+
+    primesieve::iterator rit(stop + 1, start);
+    primesieve::iterator it(low - 1, z);
+    int64_t next = it.next_prime();
+    int64_t prime = rit.prev_prime();
+
+    // \sum_{i = pi[start]+1}^{pi[stop]} pi(x / primes[i]) - pi(low - 1)
+    while (prime > start)
+    {
+      int64_t xp = (int64_t)(x / prime);
+      if (xp >= z) break;
+      pix += count_primes(it, next, xp);
+      pix_count++;
+      sum += pix;
+      prime = rit.prev_prime();
+    }
+
+    // Count the remaining primes
+    pix += count_primes(it, next, z - 1);
   }
 
-  // prime count [low, z[
-  pix += count_primes(it, next, z - 1);
-  auto res = make_tuple(sum, pix, pix_count);
-
-  return res;
+  return make_tuple(sum, pix, pix_count);
 }
 
 /// P2(x, y) counts the numbers <= x that have exactly 2
@@ -139,51 +144,58 @@ T P2_OpenMP(T x, int64_t y, int threads)
 
   int64_t low = 2;
   int64_t z = (int64_t)(x / max(y, 1));
-  int64_t min_distance = 1 << 23;
-  int64_t thread_distance = min_distance;
   int64_t pi_low_minus_1 = 0;
-
-  // prevents CPU false sharing
+  int64_t thread_distance = 1 << 23;
+  threads = ideal_num_threads(threads, z, thread_distance);
   using res_t = std::tuple<T, int64_t, int64_t>;
   aligned_vector<res_t> res(threads);
 
-  // \sum_{i=a+1}^{b} pi(x / primes[i])
-  while (low < z)
+  #pragma omp parallel num_threads(threads)
   {
-    int64_t max_threads = ceil_div(z - low, thread_distance);
-    threads = in_between(1, threads, max_threads);
-    double time = get_time();
+  #ifdef _OPENMP
+      int64_t t = omp_get_thread_num();
+  #else
+      int64_t t = 0;
+  #endif
 
-    #pragma omp parallel for num_threads(threads)
-    for (int i = 0; i < threads; i++)
-      res[i] = P2_thread(x, y, z, low, i, thread_distance);
-
-    // The threads above have computed the sum of:
-    // PrimePi(n) - PrimePi(thread_low - 1)
-    // for many different values of n. However we actually want to
-    // compute the sum of PrimePi(n). In order to get the complete
-    // sum we now have to calculate the missing sum contributions in
-    // sequential order as each thread depends on values from the
-    // previous thread. The missing sum contribution for each thread
-    // can be calculated using pi_low_minus_1 * thread_count.
-    for (int i = 0; i < threads; i++)
+    // \sum_{i=a+1}^{b} pi(x / primes[i])
+    while (low < z)
     {
-      auto thread_sum = std::get<0>(res[i]);
-      auto thread_pix = std::get<1>(res[i]);
-      auto thread_count = std::get<2>(res[i]);
-      thread_sum += (T) pi_low_minus_1 * thread_count;
-      sum += thread_sum;
-      pi_low_minus_1 += thread_pix;
-    }
+      double time = get_time();
+      res[t] = P2_thread(x, y, z, low, t, thread_distance);
 
-    low += thread_distance * threads;
-    balanceLoad(&thread_distance, low, z, threads, time);
+      // All threads have to wait here
+      #pragma omp barrier
+      #pragma omp single
+      {
+        // The threads above have computed the sum of:
+        // PrimePi(n) - PrimePi(thread_low - 1)
+        // for many different values of n. However we actually want to
+        // compute the sum of PrimePi(n). In order to get the complete
+        // sum we now have to calculate the missing sum contributions in
+        // sequential order as each thread depends on values from the
+        // previous thread. The missing sum contribution for each thread
+        // can be calculated using pi_low_minus_1 * thread_count.
+        for (int i = 0; i < threads; i++)
+        {
+          auto thread_sum = std::get<0>(res[i]);
+          auto thread_pix = std::get<1>(res[i]);
+          auto thread_count = std::get<2>(res[i]);
+          thread_sum += (T) pi_low_minus_1 * thread_count;
+          sum += thread_sum;
+          pi_low_minus_1 += thread_pix;
+        }
 
-    if (is_print())
-    {
-      double percent = get_percent(low, z);
-      cout << "\rStatus: " << fixed << setprecision(get_status_precision(x))
-           << percent << '%' << flush;
+        low += thread_distance * threads;
+        balanceLoad(&thread_distance, low, z, threads, time);
+
+        if (is_print())
+        {
+          double percent = get_percent(low, z);
+          cout << "\rStatus: " << fixed << setprecision(get_status_precision(x))
+              << percent << '%' << flush;
+        }
+      }
     }
   }
 

--- a/src/SegmentedPiTable.cpp
+++ b/src/SegmentedPiTable.cpp
@@ -84,8 +84,8 @@ const std::array<uint64_t, 128> SegmentedPiTable::unset_bits_ =
 SegmentedPiTable::SegmentedPiTable(uint64_t limit,
                                    uint64_t segment_size,
                                    int threads)
-  : max_high_(limit + 1),
-    counts_(threads),
+  : counts_(threads),
+    max_high_(limit + 1),
     threads_(threads)
 {
   // Each bit of the pi[x] lookup table corresponds

--- a/src/SegmentedPiTable.cpp
+++ b/src/SegmentedPiTable.cpp
@@ -101,10 +101,10 @@ SegmentedPiTable::SegmentedPiTable(uint64_t limit,
   // In order to simplify multi-threading we set low,
   // high and segment_size % 128 == 0.
   segment_size_ += 128 - segment_size_ % 128;
+  pi_.resize(segment_size_ / 128);
 
   high_ = segment_size_;
   high_ = std::min(high_, max_high_);
-  pi_.resize(segment_size_ / 128);
 }
 
 void SegmentedPiTable::next()
@@ -164,7 +164,7 @@ void SegmentedPiTable::init()
 #else
   uint64_t thread_size = segment_size_ / omp_get_num_threads();
   uint64_t min_thread_size = (uint64_t) 1e7;
-  thread_size = max(thread_size, min_thread_size);
+  thread_size = max(min_thread_size, thread_size);
   thread_size += 128 - thread_size % 128;
 
   uint64_t thread_num = omp_get_thread_num();

--- a/src/SegmentedPiTable.cpp
+++ b/src/SegmentedPiTable.cpp
@@ -111,11 +111,14 @@ SegmentedPiTable::SegmentedPiTable(uint64_t limit,
 /// Increase low & high and initialize the next segment.
 void SegmentedPiTable::next()
 {
-  uint64_t pi_low_minus_1 = operator[](high_ - 1);
+  #pragma omp single
+  {
+    pi_low_minus_1 = operator[](high_ - 1);
 
-  low_ = high_;
-  high_ = low_ + segment_size_;
-  high_ = std::min(high_, max_high_);
+    low_ = high_;
+    high_ = low_ + segment_size_;
+    high_ = std::min(high_, max_high_);
+  }
 
   if (finished())
     return;
@@ -164,7 +167,7 @@ void SegmentedPiTable::reset_pi(uint64_t start,
 ///
 void SegmentedPiTable::init_next_segment(uint64_t pi_low_minus_1)
 {
-  #pragma omp parallel for num_threads(threads_)
+  #pragma omp for
   for (int t = 0; t < threads_; t++)
   {
     uint64_t thread_size = segment_size_ / threads_;

--- a/src/SegmentedPiTable.cpp
+++ b/src/SegmentedPiTable.cpp
@@ -82,8 +82,11 @@ const std::array<uint64_t, 128> SegmentedPiTable::unset_bits_ =
 };
 
 SegmentedPiTable::SegmentedPiTable(uint64_t limit,
-                                   uint64_t segment_size)
-  : max_high_(limit + 1)
+                                   uint64_t segment_size,
+                                   int threads)
+  : max_high_(limit + 1),
+    counts_(threads),
+    threads_(threads)
 {
   // Each bit of the pi[x] lookup table corresponds
   // to an odd integer, so there are 16 numbers per
@@ -95,8 +98,8 @@ SegmentedPiTable::SegmentedPiTable(uint64_t limit,
   // Minimum segment size = 256 KiB (L2 cache size),
   // a large segment size improves load balancing.
   uint64_t min_segment_size = 256 * (1 << 10) * numbers_per_byte;
-  segment_size_ = std::max(segment_size, min_segment_size);
-  segment_size_ = std::min(segment_size_, max_high_);
+  segment_size_ = max(segment_size, min_segment_size);
+  segment_size_ = min(segment_size_, max_high_);
 
   // In order to simplify multi-threading we set low,
   // high and segment_size % 128 == 0.
@@ -104,14 +107,79 @@ SegmentedPiTable::SegmentedPiTable(uint64_t limit,
   pi_.resize(segment_size_ / 128);
 
   high_ = segment_size_;
-  high_ = std::min(high_, max_high_);
+  high_ = min(high_, max_high_);
+}
+
+/// Iterate over the primes inside the segment [low, high[
+/// and initialize the pi[x] lookup table. The pi[x]
+/// lookup table returns the number of primes <= x for
+/// low <= x < high.
+///
+void SegmentedPiTable::init()
+{
+#if !defined(_OPENMP)
+  uint64_t start = low_;
+  uint64_t stop = high_;
+  uint64_t thread_num = 0;
+#else
+  assert(threads_ == omp_get_num_threads());
+  uint64_t thread_size = segment_size_ / threads_;
+  uint64_t min_thread_size = (uint64_t) 1e7;
+  thread_size = max(min_thread_size, thread_size);
+  thread_size += 128 - thread_size % 128;
+
+  uint64_t thread_num = omp_get_thread_num();
+  uint64_t start = low_ + thread_size * thread_num;
+  uint64_t stop = start + thread_size;
+  stop = min(stop, high_);
+#endif
+
+  if (start < stop)
+  {
+    reset_pi(start, stop);
+
+    // Since we store only odd numbers in our lookup table,
+    // we cannot store 2 which is the only even prime.
+    // As a workaround we mark 1 as a prime (1st bit) and
+    // add a check to return 0 for pi[1].
+    if (start <= 1)
+      pi_[0].bits |= 1;
+
+    // Iterate over primes > 2
+    primesieve::iterator it(max(start, 2), stop);
+    uint64_t count = (start <= 2);
+    uint64_t prime = 0;
+
+    // Each thread iterates over the primes
+    // inside [start, stop[ and initializes
+    // the pi[x] lookup table.
+    while ((prime = it.next_prime()) < stop)
+    {
+      count += 1;
+      uint64_t p = prime - low_;
+      pi_[p / 128].bits |= 1ull << (p % 128 / 2);
+    }
+
+    counts_[thread_num] = count;
+  }
+
+  // Wait until all threads have finished
+  #pragma omp barrier
+
+  if (start < stop)
+    update_prime_count(start, stop, thread_num);
+
+  // Wait until all threads have finished
+  #pragma omp barrier
 }
 
 void SegmentedPiTable::next()
 {
   #pragma omp single
   {
-    pi_low_minus_1_ = operator[](high_ - 1);
+    // pi_low_ must be initialized before updating the
+    // member variables for the next segment.
+    pi_low_ = operator[](high_ - 1);
 
     low_ = high_;
     high_ = low_ + segment_size_;
@@ -119,9 +187,7 @@ void SegmentedPiTable::next()
   }
 }
 
-/// Reset the pi[x] lookup table using multi-threading.
-/// Each thread resets the chunk [start, stop[.
-///
+/// Each thread resets [start, stop[
 void SegmentedPiTable::reset_pi(uint64_t start,
                                 uint64_t stop)
 {
@@ -151,63 +217,35 @@ void SegmentedPiTable::reset_pi(uint64_t start,
   }
 }
 
-/// Iterate over the primes inside the segment [low, high[
-/// and initialize the pi[x] lookup table. The pi[x]
-/// lookup table returns the number of primes <= x for
-/// low <= x < high.
-///
-void SegmentedPiTable::init()
+/// Each thread computes PrimePi [start, stop[
+void SegmentedPiTable::update_prime_count(uint64_t start,
+                                          uint64_t stop,
+                                          uint64_t thread_num)
 {
-#if !defined(_OPENMP)
-  uint64_t start = low_;
-  uint64_t stop = high_;
-#else
-  uint64_t thread_size = segment_size_ / omp_get_num_threads();
-  uint64_t min_thread_size = (uint64_t) 1e7;
-  thread_size = max(min_thread_size, thread_size);
-  thread_size += 128 - thread_size % 128;
+  if (stop % 128 != 0)
+    stop += 128 - stop % 128;
 
-  uint64_t thread_num = omp_get_thread_num();
-  uint64_t start = low_ + thread_size * thread_num;
-  uint64_t stop = start + thread_size;
-  stop = min(stop, high_);
-#endif
+  // Make sure threads never write to
+  // the same pi[x] location.
+  assert(start >= low_);
+  assert(stop - low_ <= segment_size_);
+  assert(low_ % 128 == 0);
+  assert(start % 128 == 0);
+  assert(stop % 128 == 0);
 
-  if (start < stop)
+  // First compute PrimePi[start - 1]
+  uint64_t count = pi_low_;
+  for (uint64_t i = 0; i < thread_num; i++)
+    count += counts_[i];
+
+  // Convert to array indexes
+  start = (start - low_) / 128;
+  stop = (stop - low_) / 128;
+
+  for (uint64_t i = start; i < stop; i++)
   {
-    reset_pi(start, stop);
-
-    // Since we store only odd numbers in our lookup table,
-    // we cannot store 2 which is the only even prime.
-    // As a workaround we mark 1 as a prime (1st bit) and
-    // add a check to return 0 for pi[1].
-    if (start <= 1)
-      pi_[0].bits |= 1;
-
-    // Iterate over primes > 2
-    start = max(start, 2);
-    primesieve::iterator it(start, stop);
-    uint64_t prime = 0;
-
-    // Each thread iterates over the primes
-    // inside [start, stop[ and initializes
-    // the pi[x] lookup table.
-    while ((prime = it.next_prime()) < stop)
-    {
-      uint64_t p = prime - low_;
-      pi_[p / 128].bits |= 1ull << (p % 128 / 2);
-    }
-  }
-
-  // Wait until all threads have finished
-  #pragma omp barrier
-
-  // Update prime counts
-  #pragma omp single
-  for (auto& i : pi_)
-  {
-    i.prime_count = pi_low_minus_1_;
-    pi_low_minus_1_ += popcnt64(i.bits);
+    pi_[i].prime_count = count;
+    count += popcnt64(pi_[i].bits);
   }
 }
 

--- a/src/SegmentedPiTable.cpp
+++ b/src/SegmentedPiTable.cpp
@@ -23,7 +23,6 @@
 #include <primecount-internal.hpp>
 #include <primesieve.hpp>
 #include <min.hpp>
-#include <imath.hpp>
 
 #include <stdint.h>
 #include <array>

--- a/src/SegmentedPiTable.cpp
+++ b/src/SegmentedPiTable.cpp
@@ -117,22 +117,21 @@ SegmentedPiTable::SegmentedPiTable(uint64_t limit,
 ///
 void SegmentedPiTable::init()
 {
-#if !defined(_OPENMP)
-  uint64_t start = low_;
-  uint64_t stop = high_;
-  uint64_t thread_num = 0;
-#else
+#if defined(_OPENMP)
+  uint64_t thread_num = omp_get_thread_num();
   assert(threads_ == omp_get_num_threads());
+#else
+  uint64_t thread_num = 0;
+  assert(threads_ == 1);
+#endif
+
   uint64_t thread_size = segment_size_ / threads_;
   uint64_t min_thread_size = (uint64_t) 1e7;
   thread_size = max(min_thread_size, thread_size);
   thread_size += 128 - thread_size % 128;
-
-  uint64_t thread_num = omp_get_thread_num();
   uint64_t start = low_ + thread_size * thread_num;
   uint64_t stop = start + thread_size;
   stop = min(stop, high_);
-#endif
 
   if (start < stop)
   {

--- a/src/deleglise-rivat/S2_hard.cpp
+++ b/src/deleglise-rivat/S2_hard.cpp
@@ -201,8 +201,7 @@ T S2_hard_OpenMP(T x,
   int64_t max_prime = min(y, z / isqrt(y));
   PiTable pi(max_prime);
 
-  #pragma omp parallel for num_threads(threads)
-  for (int i = 0; i < threads; i++)
+  #pragma omp parallel num_threads(threads)
   {
     ThreadSettings thread;
 

--- a/src/gourdon/AC.cpp
+++ b/src/gourdon/AC.cpp
@@ -208,7 +208,7 @@ T AC_OpenMP(T x,
 
   Status status(x);
   PiTable pi(max(z, max_a_prime));
-  SegmentedPiTable segmentedPi(isqrt(x), z);
+  SegmentedPiTable segmentedPi(isqrt(x), z, threads);
 
   int64_t pi_y = pi[y];
   int64_t pi_sqrtz = pi[isqrt(z)];

--- a/src/gourdon/AC_libdivide.cpp
+++ b/src/gourdon/AC_libdivide.cpp
@@ -331,10 +331,11 @@ T AC_OpenMP(T x,
   // In order to reduce the thread creation & destruction
   // overhead we reuse the same threads throughout the
   // entire computation. The same threads are used for:
+  //
   // 1) Computation of the C1 formula.
-  // 2) Computation of the C2 formula.
-  // 3) Computation of the A formula.
-  // 4) Initialization of the segmentedPi lookup table.
+  // 2) Initialization of the segmentedPi lookup table.
+  // 3) Computation of the C2 formula.
+  // 4) Computation of the A formula.
   //
   #pragma omp parallel num_threads(threads)
   {

--- a/src/gourdon/AC_libdivide.cpp
+++ b/src/gourdon/AC_libdivide.cpp
@@ -416,7 +416,6 @@ T AC_OpenMP(T x,
           status.print(b, pi_x13);
       }
 
-      #pragma omp single
       segmentedPi.next();
     }
   }

--- a/src/gourdon/AC_libdivide.cpp
+++ b/src/gourdon/AC_libdivide.cpp
@@ -311,7 +311,7 @@ T AC_OpenMP(T x,
 
   Status status(x);
   PiTable pi(max(z, max_a_prime));
-  SegmentedPiTable segmentedPi(isqrt(x), z);
+  SegmentedPiTable segmentedPi(isqrt(x), z, threads);
 
   // Initialize libdivide vector using primes
   using libdivide_t = libdivide::branchfree_divider<uint64_t>;

--- a/src/gourdon/AC_libdivide.cpp
+++ b/src/gourdon/AC_libdivide.cpp
@@ -358,11 +358,10 @@ T AC_OpenMP(T x,
     // Since we need to lookup PrimePi[n] values for n <= x^(1/2)
     // we use a segmented PrimePi[n] table of size z (~O(x^1/3))
     // in order to reduce the memory usage.
-    for (; !segmentedPi.finished(); segmentedPi.next())
+    for (; segmentedPi.has_next(); segmentedPi.next())
     {
-      segmentedPi.init();
-
       // Current segment [low, high[
+      segmentedPi.init();
       int64_t low = segmentedPi.low();
       int64_t high = segmentedPi.high();
       low = max(low, 1);

--- a/src/gourdon/AC_libdivide.cpp
+++ b/src/gourdon/AC_libdivide.cpp
@@ -368,11 +368,11 @@ T AC_OpenMP(T x,
       T xhigh = x / high;
 
       // Lower bounds of C2 formula
-      int64_t min_b = max(k, pi_root3_xy);
-      min_b = max(min_b, pi_sqrtz);
-      min_b = max(min_b, pi[isqrt(low)]);
-      min_b = max(min_b, pi[min(xhigh / y, x_star)]);
-      min_b += 1;
+      int64_t min_c2 = max(k, pi_root3_xy);
+      min_c2 = max(min_c2, pi_sqrtz);
+      min_c2 = max(min_c2, pi[isqrt(low)]);
+      min_c2 = max(min_c2, pi[min(xhigh / y, x_star)]);
+      min_c2 += 1;
 
       // Upper bound of A & C2 formulas:
       // x / (p * q) >= low
@@ -384,7 +384,7 @@ T AC_OpenMP(T x,
       // C2 formula: pi[sqrt(z)] < b <= pi[x_star]
       // A  formula: pi[x_star] < b <= pi[x13]
       #pragma omp for schedule(dynamic) reduction(+: sum)
-      for (int64_t b = min_b; b <= max_b; b++)
+      for (int64_t b = min_c2; b <= max_b; b++)
       {
         int64_t prime = primes[b];
         T xp = x / prime;

--- a/src/gourdon/B.cpp
+++ b/src/gourdon/B.cpp
@@ -10,7 +10,7 @@
 ///        B(x, y) formula:
 ///        \sum_{i=pi[y]+1}^{pi[x^(1/2)]} pi(x / primes[i])
 ///
-/// Copyright (C) 2019 Kim Walisch, <kim.walisch@gmail.com>
+/// Copyright (C) 2020 Kim Walisch, <kim.walisch@gmail.com>
 ///
 /// This file is distributed under the BSD License. See the COPYING
 /// file in the top level directory.
@@ -31,6 +31,10 @@
 #include <iostream>
 #include <iomanip>
 #include <tuple>
+
+#ifdef _OPENMP
+  #include <omp.h>
+#endif
 
 using namespace std;
 using namespace primecount;
@@ -83,35 +87,36 @@ B_thread(T x,
   T sum = 0;
   int64_t pix = 0;
   int64_t pix_count = 0;
-
-  // thread sieves [low, z[
   low += thread_distance * thread_num;
-  z = min(low + thread_distance, z);
-  int64_t start = (int64_t) max(x / z, y);
-  int64_t stop = (int64_t) min(x / low, isqrt(x));
 
-  primesieve::iterator rit(stop + 1, start);
-  primesieve::iterator it(low - 1, z);
-
-  int64_t next = it.next_prime();
-  int64_t prime = rit.prev_prime();
-
-  // \sum_{i = pi[start]+1}^{pi[stop]} pi(x / primes[i]) - pi(low - 1)
-  while (prime > start)
+  if (low < z)
   {
-    int64_t xp = (int64_t)(x / prime);
-    if (xp >= z) break;
-    pix += count_primes(it, next, xp);
-    pix_count++;
-    sum += pix;
-    prime = rit.prev_prime();
+    // thread sieves [low, z[
+    z = min(low + thread_distance, z);
+    int64_t start = (int64_t) max(x / z, y);
+    int64_t stop = (int64_t) min(x / low, isqrt(x));
+
+    primesieve::iterator rit(stop + 1, start);
+    primesieve::iterator it(low - 1, z);
+    int64_t next = it.next_prime();
+    int64_t prime = rit.prev_prime();
+
+    // \sum_{i = pi[start]+1}^{pi[stop]} pi(x / primes[i]) - pi(low - 1)
+    while (prime > start)
+    {
+      int64_t xp = (int64_t)(x / prime);
+      if (xp >= z) break;
+      pix += count_primes(it, next, xp);
+      pix_count++;
+      sum += pix;
+      prime = rit.prev_prime();
+    }
+
+    // Count the remaining primes
+    pix += count_primes(it, next, z - 1);
   }
 
-  // prime count [low, z[
-  pix += count_primes(it, next, z - 1);
-  auto res = make_tuple(sum, pix, pix_count);
-
-  return res;
+  return make_tuple(sum, pix, pix_count);
 }
 
 /// \sum_{i=pi[y]+1}^{pi[x^(1/2)]} pi(x / primes[i])
@@ -127,50 +132,57 @@ T B_OpenMP(T x, int64_t y, int threads)
   T sum = 0;
   int64_t low = 2;
   int64_t z = (int64_t)(x / max(y, 1));
-  int64_t min_distance = 1 << 23;
-  int64_t thread_distance = min_distance;
   int64_t pi_low_minus_1 = 0;
-
-  // prevents CPU false sharing
+  int64_t thread_distance = 1 << 23;
+  threads = ideal_num_threads(threads, z, thread_distance);
   using res_t = std::tuple<T, int64_t, int64_t>;
   aligned_vector<res_t> res(threads);
 
-  while (low < z)
+  #pragma omp parallel num_threads(threads)
   {
-    int64_t max_threads = ceil_div(z - low, thread_distance);
-    threads = in_between(1, threads, max_threads);
-    double time = get_time();
+  #ifdef _OPENMP
+      int64_t t = omp_get_thread_num();
+  #else
+      int64_t t = 0;
+  #endif
 
-    #pragma omp parallel for num_threads(threads)
-    for (int i = 0; i < threads; i++)
-      res[i] = B_thread(x, y, z, low, i, thread_distance);
-
-    // The threads above have computed the sum of:
-    // PrimePi(n) - PrimePi(thread_low - 1)
-    // for many different values of n. However we actually want to
-    // compute the sum of PrimePi(n). In order to get the complete
-    // sum we now have to calculate the missing sum contributions in
-    // sequential order as each thread depends on values from the
-    // previous thread. The missing sum contribution for each thread
-    // can be calculated using pi_low_minus_1 * thread_count.
-    for (int i = 0; i < threads; i++)
+    while (low < z)
     {
-      auto thread_sum = std::get<0>(res[i]);
-      auto thread_pix = std::get<1>(res[i]);
-      auto thread_count = std::get<2>(res[i]);
-      thread_sum += (T) pi_low_minus_1 * thread_count;
-      sum += thread_sum;
-      pi_low_minus_1 += thread_pix;
-    }
+      double time = get_time();
+      res[t] = B_thread(x, y, z, low, t, thread_distance);
 
-    low += thread_distance * threads;
-    balanceLoad(&thread_distance, low, z, threads, time);
+      // All threads have to wait here
+      #pragma omp barrier
+      #pragma omp single
+      {
+        // The threads above have computed the sum of:
+        // PrimePi(n) - PrimePi(thread_low - 1)
+        // for many different values of n. However we actually want to
+        // compute the sum of PrimePi(n). In order to get the complete
+        // sum we now have to calculate the missing sum contributions in
+        // sequential order as each thread depends on values from the
+        // previous thread. The missing sum contribution for each thread
+        // can be calculated using pi_low_minus_1 * thread_count.
+        for (int i = 0; i < threads; i++)
+        {
+          auto thread_sum = std::get<0>(res[i]);
+          auto thread_pix = std::get<1>(res[i]);
+          auto thread_count = std::get<2>(res[i]);
+          thread_sum += (T) pi_low_minus_1 * thread_count;
+          sum += thread_sum;
+          pi_low_minus_1 += thread_pix;
+        }
 
-    if (is_print())
-    {
-      double percent = get_percent(low, z);
-      cout << "\rStatus: " << fixed << setprecision(get_status_precision(x))
-           << percent << '%' << flush;
+        low += thread_distance * threads;
+        balanceLoad(&thread_distance, low, z, threads, time);
+
+        if (is_print())
+        {
+          double percent = get_percent(low, z);
+          cout << "\rStatus: " << fixed << setprecision(get_status_precision(x))
+              << percent << '%' << flush;
+        }
+      }
     }
   }
 

--- a/src/gourdon/D.cpp
+++ b/src/gourdon/D.cpp
@@ -198,8 +198,7 @@ T D_OpenMP(T x,
   PiTable pi(y);
   LoadBalancer loadBalancer(x, xz, d_approx);
 
-  #pragma omp parallel for num_threads(threads)
-  for (int i = 0; i < threads; i++)
+  #pragma omp parallel num_threads(threads)
   {
     ThreadSettings thread;
 

--- a/src/lmo/pi_lmo_parallel.cpp
+++ b/src/lmo/pi_lmo_parallel.cpp
@@ -179,8 +179,7 @@ int64_t S2(int64_t x,
   LoadBalancer loadBalancer(x, z, s2_approx);
   PiTable pi(y);
 
-  #pragma omp parallel for num_threads(threads)
-  for (int i = 0; i < threads; i++)
+  #pragma omp parallel num_threads(threads)
   {
     ThreadSettings thread;
 

--- a/test/segmented_pi_table.cpp
+++ b/test/segmented_pi_table.cpp
@@ -10,7 +10,6 @@
 
 #include <PiTable.hpp>
 #include <SegmentedPiTable.hpp>
-#include <primecount.hpp>
 #include <imath.hpp>
 
 #include <stdint.h>

--- a/test/segmented_pi_table.cpp
+++ b/test/segmented_pi_table.cpp
@@ -37,7 +37,7 @@ int main()
 
   int64_t limit = dist(gen);
   int64_t segment_size = iroot<3>(limit);
-  int64_t threads = 1;
+  int threads = 1;
 
   PiTable pi(limit);
   SegmentedPiTable segmentedPi(limit, segment_size, threads);

--- a/test/segmented_pi_table.cpp
+++ b/test/segmented_pi_table.cpp
@@ -2,7 +2,7 @@
 /// @file   segmented_pi_table.cpp
 /// @brief  Test the SegmentedPiTable class
 ///
-/// Copyright (C) 2019 Kim Walisch, <kim.walisch@gmail.com>
+/// Copyright (C) 2020 Kim Walisch, <kim.walisch@gmail.com>
 ///
 /// This file is distributed under the BSD License. See the COPYING
 /// file in the top level directory.
@@ -37,17 +37,20 @@ int main()
 
   int64_t limit = dist(gen);
   int64_t segment_size = iroot<3>(limit);
-  int threads = get_num_threads();
 
   PiTable pi(limit);
-  SegmentedPiTable segmentedPi(limit, segment_size, threads);
+  SegmentedPiTable segmentedPi(limit, segment_size);
+  segmentedPi.init();
   int64_t i = 0;
 
   // Check small pi(x) values
   for (; i <= 1000; i++)
   {
     while (i >= segmentedPi.high())
+    {
       segmentedPi.next();
+      segmentedPi.init();
+    }
 
     cout << "segmentedPi(" << i << ") = " << segmentedPi[i];
     check(segmentedPi[i] == pi[i]);
@@ -57,14 +60,20 @@ int main()
   for (; i < limit; i += dist2(gen))
   {
     while (i >= segmentedPi.high())
+    {
       segmentedPi.next();
+      segmentedPi.init();
+    }
 
     cout << "segmentedPi(" << i << ") = " << segmentedPi[i];
     check(segmentedPi[i] == pi[i]);
   }
 
   while (limit >= segmentedPi.high())
+  {
     segmentedPi.next();
+    segmentedPi.init();
+  }
 
   // Check max pi(x) value
   cout << "segmentedPi(" << limit << ") = " << segmentedPi[limit];

--- a/test/segmented_pi_table.cpp
+++ b/test/segmented_pi_table.cpp
@@ -37,9 +37,10 @@ int main()
 
   int64_t limit = dist(gen);
   int64_t segment_size = iroot<3>(limit);
+  int64_t threads = 1;
 
   PiTable pi(limit);
-  SegmentedPiTable segmentedPi(limit, segment_size);
+  SegmentedPiTable segmentedPi(limit, segment_size, threads);
   segmentedPi.init();
   int64_t i = 0;
 


### PR DESCRIPTION
Avoid thread creation & destruction overhead by reusing the same threads throughout the entire computation.