### PR TITLE
Use dynamic thread scheduling whenever possible

### DIFF
--- a/src/PiTable.cpp
+++ b/src/PiTable.cpp
@@ -86,7 +86,7 @@ PiTable::PiTable(uint64_t limit, int threads) :
 
   #pragma omp parallel num_threads(threads)
   {
-    #pragma omp for
+    #pragma omp for schedule(dynamic)
     for (int t = 0; t < threads; t++)
     {
       uint64_t start = thread_size * t;
@@ -97,7 +97,7 @@ PiTable::PiTable(uint64_t limit, int threads) :
         init_bits(start, stop, t);
     }
 
-    #pragma omp for
+    #pragma omp for schedule(dynamic)
     for (int t = 0; t < threads; t++)
     {
       uint64_t start = thread_size * t;

--- a/src/deleglise-rivat/S2_easy_libdivide.cpp
+++ b/src/deleglise-rivat/S2_easy_libdivide.cpp
@@ -47,8 +47,8 @@ T S2_easy_64(T xp128,
              uint64_t z,
              uint64_t b,
              uint64_t prime,
-             const PiTable& pi,
-             const LibdividePrimes& primes)
+             const LibdividePrimes& primes,
+             const PiTable& pi)
 {
   uint64_t xp = (uint64_t) xp128;
   uint64_t min_trivial = min(xp / prime, y);
@@ -99,8 +99,8 @@ T S2_easy_128(T xp,
               uint64_t z,
               uint64_t b,
               uint64_t prime,
-              const PiTable& pi,
-              const Primes& primes)
+              const Primes& primes,
+              const PiTable& pi)
 {
   uint64_t min_trivial = min(xp / prime, y);
   uint64_t min_clustered = (uint64_t) isqrt(xp);
@@ -177,9 +177,9 @@ T S2_easy_OpenMP(T x,
     T xp = x / prime;
 
     if (xp <= numeric_limits<uint64_t>::max())
-      s2_easy += S2_easy_64(xp, y, z, b, prime, pi, lprimes);
+      s2_easy += S2_easy_64(xp, y, z, b, prime, lprimes, pi);
     else
-      s2_easy += S2_easy_128(xp, y, z, b, prime, pi, primes);
+      s2_easy += S2_easy_128(xp, y, z, b, prime, primes, pi);
 
     status.print(b, pi_x13);
   }

--- a/src/gourdon/SegmentedPiTable.cpp
+++ b/src/gourdon/SegmentedPiTable.cpp
@@ -118,7 +118,7 @@ void SegmentedPiTable::init()
   thread_size = max(min_thread_size, thread_size);
   thread_size += 128 - thread_size % 128;
 
-  #pragma omp for
+  #pragma omp for schedule(dynamic)
   for (int t = 0; t < threads_; t++)
   {
     uint64_t start = low_ + thread_size * t;
@@ -129,7 +129,7 @@ void SegmentedPiTable::init()
       init_bits(start, stop, t);
   }
 
-  #pragma omp for
+  #pragma omp for schedule(dynamic)
   for (int t = 0; t < threads_; t++)
   {
     uint64_t start = low_ + thread_size * t;
@@ -203,7 +203,7 @@ void SegmentedPiTable::next()
   // Wait until all threads have finished
   // computing the current segment.
   #pragma omp barrier
-  #pragma omp master
+  #pragma omp single
   {
     // pi_low_ must be initialized before updating the
     // member variables for the next segment.
@@ -213,8 +213,6 @@ void SegmentedPiTable::next()
     high_ = low_ + segment_size_;
     high_ = std::min(high_, max_high_);
   }
-
-  #pragma omp barrier
 }
 
 } // namespace


### PR DESCRIPTION
With the introduction of Little.Big CPUs (Apple M1) some CPU cores are faster than others so from a theoretical point of view is does not make sense to assign equally sized work chunks to each CPU core.