### PR TITLE
set minimal version of external primesieve

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,7 +267,7 @@ if(BUILD_LIBPRIMESIEVE)
     set(BUILD_MANPAGE "${COPY_BUILD_MANPAGE}" CACHE BOOL "Regenerate man page using a2x" FORCE)
     set(BUILD_TESTS "${COPY_BUILD_TESTS}" CACHE BOOL "Build test programs" FORCE)
 else()
-    find_package(primesieve REQUIRED)
+    find_package(primesieve 7.6 REQUIRED)
 endif()
 
 # Testing ############################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,7 +267,7 @@ if(BUILD_LIBPRIMESIEVE)
     set(BUILD_MANPAGE "${COPY_BUILD_MANPAGE}" CACHE BOOL "Regenerate man page using a2x" FORCE)
     set(BUILD_TESTS "${COPY_BUILD_TESTS}" CACHE BOOL "Build test programs" FORCE)
 else()
-    find_package(primesieve 7.6 REQUIRED)
+    find_package(primesieve 7 REQUIRED)
 endif()
 
 # Testing ############################################################


### PR DESCRIPTION
At the moment    one has  [find_package(primesieve REQUIRED)](https://github.com/kimwalisch/primecount/blob/4d33e82a13ef51db4670b34e93d41862c0f3ea5c/CMakeLists.txt#L270] - any version will be accepted. However, some distributions still carry very old primesieve, and one doesn't want them.