### PR TITLE
Improve sieve cache efficiency

### DIFF
--- a/include/LoadBalancerS2.hpp
+++ b/include/LoadBalancerS2.hpp
@@ -1,7 +1,7 @@
 ///
 /// @file  LoadBalancerS2.hpp
 ///
-/// Copyright (C) 2022 Kim Walisch, <kim.walisch@gmail.com>
+/// Copyright (C) 2025 Kim Walisch, <kim.walisch@gmail.com>
 ///
 /// This file is distributed under the BSD License. See the COPYING
 /// file in the top level directory.
@@ -61,7 +61,6 @@ public:
 private:
   void update_load_balancing(const ThreadData& thread);
   void update_number_of_segments(const ThreadData& thread);
-  void update_segment_size();
   double remaining_secs() const;
 
   int64_t low_ = 0;
@@ -69,7 +68,7 @@ private:
   int64_t sieve_limit_ = 0;
   int64_t segments_ = 0;
   int64_t segment_size_ = 0;
-  int64_t max_size_ = 0;
+  int64_t cache_segment_size_ = 0;
   maxint_t sum_ = 0;
   maxint_t sum_approx_ = 0;
   double time_ = 0;

--- a/src/LoadBalancerS2.cpp
+++ b/src/LoadBalancerS2.cpp
@@ -158,8 +158,8 @@ void LoadBalancerS2::update_load_balancing(const ThreadData& thread)
     // Slowly increase the segment size until it reaches
     // sqrt(high). Most special leaves are located around y,
     // hence we need to be careful to not assign too much work
-    // (i.e. too large segment size) to a single thread in
-    // this region.
+    // (i.e. use too large segment size) to a single thread
+    // in this region.
     if (segment_size_ < new_segment_size)
     {
       segment_size_ += segment_size_ / 16;

--- a/src/LoadBalancerS2.cpp
+++ b/src/LoadBalancerS2.cpp
@@ -158,9 +158,6 @@ void LoadBalancerS2::update_load_balancing(const ThreadData& thread)
       segment_size_ = Sieve::align_segment_size(segment_size_);
     }
 
-    ASSERT(segment_size_ % 240);
-    ASSERT(cache_segment_size_ % 240);
-
     if (segment_size_ >= cache_segment_size_)
       update_number_of_segments(thread);
   }

--- a/src/LoadBalancerS2.cpp
+++ b/src/LoadBalancerS2.cpp
@@ -145,11 +145,11 @@ void LoadBalancerS2::update_load_balancing(const ThreadData& thread)
     // The segmented sieve of Eratosthenes traditionally
     // requires using a segment size of O(sqrt(x)), using a
     // smaller segment size deteriorates the runtime complexity.
-    // However, it is also possible to use a smaller segment
-    // size of O(sqrt(high)) that is dynamically increased
-    // after each sieved sieved segment. Using this smaller
-    // segment size of O(sqrt(high)) uses less memory and is
-    // hence more cache efficient.
+    // However, it is possible to use a smaller segment size
+    // of O(sqrt(high)) provided that it is dynamically
+    // increased after each sieved sieved segment. Using this
+    // smaller segment size of O(sqrt(high)) uses less memory
+    // and is hence more cache efficient.
     int64_t high = low_ + segment_size_ * segments_;
     high = min(high, sieve_limit_);
     int64_t new_segment_size = isqrt(high);

--- a/src/LoadBalancerS2.cpp
+++ b/src/LoadBalancerS2.cpp
@@ -139,9 +139,14 @@ void LoadBalancerS2::update_load_balancing(const ThreadData& thread)
     if (sum_ == 0)
       return;
 
-    // The segmented sieve of Eratosthenes requires using a
-    // segment size >= O(sqrt(high)). Using a smaller
-    // segment size deteriorates the runtime complexity.
+    // The segmented sieve of Eratosthenes traditionally
+    // requires using a segment size of O(sqrt(x)), using a
+    // smaller segment size deteriorates the runtime complexity.
+    // However, it is also possible to use a smaller segment
+    // size of O(sqrt(high)) that is dynamically increased
+    // after each sieved sieved segment. Using this smaller
+    // segment size of O(sqrt(high)) uses less memory and is
+    // hence more cache efficient.
     int64_t high = low_ + segment_size_ * segments_;
     high = min(high, sieve_limit_);
     int64_t new_segment_size = isqrt(high);


### PR DESCRIPTION
For large computations ≥ 10^26 primecount's sieve algorithm uses a large sieve array with a fixed size of O(sqrt(x)) that does not fit into the CPU's cache. This causes severe scaling issues for large computations. This pull request sets the size of the sieve array to O(sqrt(segment_high)) which is much smaller and hence much more cache efficient. The size of the sieve array is then dynamically increased after each sieved segment.