### PR TITLE
New lockfree thread load balancer

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
-Changes in primecount-8.5, 2026-04-23
+Changes in primecount-8.5, 2026-04-24
 
+* LoadBalancerAC.cpp: Use lockfree implementation, get rid of mutex.
 * LoadBalancerP2.cpp: Use lockfree implementation, get rid of mutex.
 * nth_prime.cpp: Use new nth_prime_sieve() implementation.
 * nth_prime_sieve.cpp: Improved multi-threading.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
-Changes in primecount-8.5, 2026-04-14
+Changes in primecount-8.5, 2026-04-23
 
+* LoadBalancerP2.cpp: Use lockfree implementation, get rid of mutex.
 * nth_prime.cpp: Use new nth_prime_sieve() implementation.
 * nth_prime_sieve.cpp: Improved multi-threading.
 * RiemannR.cpp: Add RiemannR(psi(x)) implementation.

--- a/include/TryLockGuard.hpp
+++ b/include/TryLockGuard.hpp
@@ -15,14 +15,7 @@
 #include <atomic>
 
 namespace {
- 
-/// For printing the status it is OK to use a non-blocking
-/// userspace lock because printing the status is a non
-/// essential operation and hence even if the OS preempts
-/// the thread holding the lock it won't cause any deadlocks
-/// or performance issues, it will only delay the status
-/// output.
-///
+
 struct TryLockGuard
 {
   public:

--- a/include/TryLockGuard.hpp
+++ b/include/TryLockGuard.hpp
@@ -18,23 +18,23 @@ namespace {
 
 struct TryLockGuard
 {
-  public:
+public:
   TryLockGuard(std::atomic<bool>& lock)
-      : lock_(&lock)
+    : lock_(&lock)
   {
-      bool expected = false;
-      is_locked_ = lock.compare_exchange_weak(expected, true, std::memory_order_acquire);
+    bool expected = false;
+    is_locked_ = lock.compare_exchange_weak(expected, true, std::memory_order_acquire);
   }
   ~TryLockGuard()
   {
-      if (is_locked_)
+    if (is_locked_)
       lock_->store(false, std::memory_order_release);
   }
   bool owns_lock() const
   {
-      return is_locked_;
+    return is_locked_;
   }
-  private:
+private:
   std::atomic<bool>* lock_ = nullptr;
   bool is_locked_ = false;
 };

--- a/include/TryLockGuard.hpp
+++ b/include/TryLockGuard.hpp
@@ -1,0 +1,51 @@
+ ///
+/// @file   TryLockGuard.hpp
+/// @brief  The TryLockGuard class is a RAII-style wrapper
+///         for a fast lock using std::atomic.
+///
+/// Copyright (C) 2026 Kim Walisch, <kim.walisch@gmail.com>
+///
+/// This file is distributed under the BSD License. See the COPYING
+/// file in the top level directory.
+///
+
+#ifndef TRYLOCKGUARD_HPP
+#define TRYLOCKGUARD_HPP
+
+#include <atomic>
+
+namespace {
+ 
+/// For printing the status it is OK to use a non-blocking
+/// userspace lock because printing the status is a non
+/// essential operation and hence even if the OS preempts
+/// the thread holding the lock it won't cause any deadlocks
+/// or performance issues, it will only delay the status
+/// output.
+///
+struct TryLockGuard
+{
+  public:
+  TryLockGuard(std::atomic<bool>& lock)
+      : lock_(&lock)
+  {
+      bool expected = false;
+      is_locked_ = lock.compare_exchange_weak(expected, true, std::memory_order_acquire);
+  }
+  ~TryLockGuard()
+  {
+      if (is_locked_)
+      lock_->store(false, std::memory_order_release);
+  }
+  bool owns_lock() const
+  {
+      return is_locked_;
+  }
+  private:
+  std::atomic<bool>* lock_ = nullptr;
+  bool is_locked_ = false;
+};
+
+} // namespace
+
+#endif

--- a/src/LoadBalancerP2.cpp
+++ b/src/LoadBalancerP2.cpp
@@ -126,6 +126,12 @@ void LoadBalancerP2::print_P2_status(int64_t low)
     return;
 #endif
 
+  // For printing the status it is OK to use a non-blocking
+  // userspace lock because printing the status is a non
+  // essential operation and hence even if the OS preempts
+  // the thread holding the lock it won't cause any deadlocks
+  // or performance issues, it will only delay the status
+  // output.
   TryLockGuard guard(print_lock_);
 
   if (guard.owns_lock())

--- a/src/LoadBalancerP2.cpp
+++ b/src/LoadBalancerP2.cpp
@@ -4,7 +4,7 @@
 ///        computation of the 2nd partial sieve function.
 ///        It is used by the P2(x, a) and B(x, y) functions.
 ///
-/// Copyright (C) 2025 Kim Walisch, <kim.walisch@gmail.com>
+/// Copyright (C) 2026 Kim Walisch, <kim.walisch@gmail.com>
 ///
 /// This file is distributed under the BSD License. See the COPYING
 /// file in the top level directory.
@@ -18,6 +18,7 @@
 
 #include <stdint.h>
 #include <algorithm>
+#include <atomic>
 #include <cmath>
 #include <string>
 
@@ -28,21 +29,21 @@ LoadBalancerP2::LoadBalancerP2(maxint_t x,
                                int64_t sieve_limit,
                                int threads,
                                bool is_print) :
-  low_(isqrt(x)),
   sieve_limit_(sieve_limit),
   precision_(get_status_precision(x)),
   is_print_(is_print)
 {
-  low_ = min(low_, sieve_limit_);
-  int64_t dist = sieve_limit_ - low_;
+  int64_t low = isqrt(x);
+  low = min(low, sieve_limit_);
+  int64_t dist = sieve_limit_ - low;
+  atomic_low_ = low;
 
   // These load balancing settings work well on my
   // dual-socket AMD EPYC 7642 server with 192 CPU cores.
   min_thread_dist_ = 1 << 23;
-  int max_threads = (int) std::pow(sieve_limit_, 1 / 3.7);
-  threads = std::min(threads, max_threads);
+  double max_threads = std::pow(sieve_limit_, 1 / 3.7);
+  threads = std::min(threads, (int) max_threads);
   threads_ = ideal_num_threads(dist, threads, min_thread_dist_);
-  lock_.init(threads_);
 
   // Using more chunks per thread improves load
   // balancing but also adds some overhead.
@@ -56,84 +57,116 @@ int LoadBalancerP2::get_threads() const
   return threads_;
 }
 
-/// The thread needs to sieve [low, high[
+/// Assign new [low, high[ workload to thread.
+/// Multiple threads may call get_work() simultaneously, since
+/// this function is not protected by a mutex, it must not
+/// modify any shared member variables, except atomic_low_.
+///
 bool LoadBalancerP2::get_work(int64_t& low, int64_t& high)
 {
-  std::string status;
-  bool has_work;
+  // Calculate the remaining sieving distance
+  low = atomic_low_.load(std::memory_order_relaxed);
+  low = min(low, sieve_limit_);
+  int64_t dist = sieve_limit_ - low;
+  int64_t thread_dist = thread_dist_;
 
+  if (threads_ == 1)
   {
-    LockGuard lockGuard(lock_);
+    // When using a single thread (and printing is disabled) we
+    // can set thread_dist to the entire sieving distance since
+    // load balancing is only useful for multi-threading.
+    if (!is_print_)
+      thread_dist = dist;
+  }
+  else
+  {
+    // Ensure that the thread initialization i.e. the calculation of
+    // PrimePi(low) uses less time than the actual computation.
+    // Computing PrimePi(low) uses O(low^(2/3) / log(low)^2) time
+    // whereas sieving a distance of n = low^(2/3) uses O(n log log n)
+    // time. Hence, the sieving time is larger than the initialization
+    // time. Using these settings for low = 2e14 the sieving time is
+    // 5x larger than the initialization time on my AMD EPYC 7642 CPU.
+    double low13 = std::cbrt(low);
+    int64_t low23 = (int64_t) (low13 * low13);
+    int64_t min_thread_dist = std::max(min_thread_dist_, low23);
+    thread_dist = max(min_thread_dist, thread_dist);
 
-    if (is_print_)
-      status = get_status();
-
-    // Calculate the remaining sieving distance
-    low_ = min(low_, sieve_limit_);
-    int64_t dist = sieve_limit_ - low_;
-
-    // When a single thread is used (and printing is disabled)
-    // we can set thread_dist to the entire sieving distance
-    // as load balancing is only useful for multi-threading.
-    if (threads_ == 1)
-    {
-      if (!is_print_)
-        thread_dist_ = dist;
-    }
-    else
-    {
-      // Ensure that the thread initialization i.e. the calculation
-      // of PrimePi(low) uses less time than the actual computation.
-      // Computing PrimePi(low) uses O(low^(2/3) / log(low)^2) time but
-      // sieving a distance of n = low^(2/3) uses O(n log log n) time,
-      // hence the sieving time is larger than the initialization time.
-      // Using these settings for low = 2e14 the sieving time is 5x
-      // larger than the initialization time on my AMD EPYC 7642 CPU.
-      double low13 = std::cbrt(low_);
-      int64_t low23 = (int64_t) (low13 * low13);
-      min_thread_dist_ = std::max(min_thread_dist_, low23);
-      thread_dist_ = max(min_thread_dist_, thread_dist_);
-
-      // Reduce the thread distance near to end to keep all
-      // threads busy until the computation finishes.
-      int64_t max_thread_dist = dist / threads_;
-      if (thread_dist_ > max_thread_dist)
-        thread_dist_ = max(min_thread_dist_, max_thread_dist);
-    }
-
-    low = low_;
-    low_ += thread_dist_;
-    low_ = min(low_, sieve_limit_);
-    high = low_;
-    has_work = low < sieve_limit_;
+    // Reduce the thread distance near to end to keep all
+    // threads busy until the computation finishes.
+    int64_t max_thread_dist = dist / threads_;
+    if (thread_dist > max_thread_dist)
+      thread_dist = max(min_thread_dist, max_thread_dist);
   }
 
-  // Printing to the terminal incurs a system call
-  // and may hence be slow. Therefore, we do it
-  // after having released the mutex.
-  if (!status.empty())
-    print_status(status);
+  low = atomic_low_.fetch_add(thread_dist, std::memory_order_relaxed);
+  high = low + thread_dist;
+  high = min(high, sieve_limit_);
+  bool has_work = low < sieve_limit_;
+
+  // The lockfree critical section above should complete as
+  // fast as possible. Hence, printing should be done
+  // afterwards since it may incur a system call.
+  if (is_print_)
+    print_P2_status(low);
 
   return has_work;
 }
 
-std::string LoadBalancerP2::get_status()
+void LoadBalancerP2::print_P2_status(int64_t low)
 {
-  double time = get_time();
-  double old = time_;
-  double threshold = 0.1;
-
-  if ((time - old) >= threshold)
+  // For printing the status it is OK to use a non-blocking
+  // userspace lock because printing the status is a non
+  // essential operation and hence even if the OS preempts
+  // the thread holding the lock it won't cause any deadlocks
+  // or performance issues, it will only delay the status
+  // output.
+  struct LockGuard
   {
-    time_ = time;
-    double percent = get_percent(low_, sieve_limit_);
-    std::string status = "Status: ";
-    status += to_string(percent, precision_);
-    status += '%';
-    return status;
-  }
+  public:
+    LockGuard(std::atomic<bool>& lock)
+      : lock_(&lock)
+    {
+      bool expected = false;
+      is_locked_ = lock.compare_exchange_weak(expected, true, std::memory_order_acquire);
+    }
+    ~LockGuard()
+    {
+      if (is_locked_)
+        lock_->store(false, std::memory_order_release);
+    }
+    bool owns_lock() const
+    {
+      return is_locked_;
+    }
+  private:
+    std::atomic<bool>* lock_ = nullptr;
+    bool is_locked_ = false;
+  };
 
-  return std::string();
+  LockGuard lockGuard(print_lock_);
+
+  if (lockGuard.owns_lock())
+  {
+    double time = get_time();
+    double old = time_;
+    double threshold = 0.1;
+
+    if ((time - old) >= threshold)
+    {
+      double percent = get_percent(low, sieve_limit_);
+
+      if (percent > percent_)
+      {
+        time_ = time;
+        percent_ = percent;
+        std::string status = "Status: ";
+        status += to_string(percent, precision_);
+        status += '%';
+        print_status(status);
+      }
+    }
+  }
 }
 
 } // namespace

--- a/src/LoadBalancerP2.cpp
+++ b/src/LoadBalancerP2.cpp
@@ -37,7 +37,7 @@ LoadBalancerP2::LoadBalancerP2(maxint_t x,
   int64_t low = isqrt(x);
   low = min(low, sieve_limit_);
   int64_t dist = sieve_limit_ - low;
-  atomic_low_ = low;
+  atomic_low_.store(low, std::memory_order_relaxed);
 
   // These load balancing settings work well on my
   // dual-socket AMD EPYC 7642 server with 192 CPU cores.

--- a/src/LoadBalancerP2.cpp
+++ b/src/LoadBalancerP2.cpp
@@ -65,7 +65,10 @@ int LoadBalancerP2::get_threads() const
 bool LoadBalancerP2::get_work(int64_t& low, int64_t& high)
 {
   low = low_.load(std::memory_order_relaxed);
-  low = min(low, sieve_limit_);
+
+  if (low >= sieve_limit_)
+    return false;
+
   int64_t dist = sieve_limit_ - low;
   int64_t thread_dist = thread_dist_;
 
@@ -101,14 +104,15 @@ bool LoadBalancerP2::get_work(int64_t& low, int64_t& high)
   low = low_.fetch_add(thread_dist, std::memory_order_relaxed);
   high = low + thread_dist;
   high = min(high, sieve_limit_);
+  bool has_work = low < sieve_limit_;
 
   // The lockfree critical section above should complete
   // as fast as possible. Hence, printing should be done
   // afterwards since it may incur a system call.
-  if (is_print_)
+  if (is_print_ && has_work)
     print_P2_status(low);
 
-  return low < sieve_limit_;
+  return has_work;
 }
 
 void LoadBalancerP2::print_P2_status(int64_t low)

--- a/src/LoadBalancerP2.cpp
+++ b/src/LoadBalancerP2.cpp
@@ -101,6 +101,9 @@ bool LoadBalancerP2::get_work(int64_t& low, int64_t& high)
       thread_dist = max(min_thread_dist, max_thread_dist);
   }
 
+  // The earlier loads are used for heuristic chunk
+  // sizing, it is OK if they are slightly outdated. This
+  // fetch_add() reserves unique work for this thread.
   low = low_.fetch_add(thread_dist, std::memory_order_relaxed);
   high = low + thread_dist;
   high = min(high, sieve_limit_);

--- a/src/LoadBalancerP2.cpp
+++ b/src/LoadBalancerP2.cpp
@@ -15,6 +15,7 @@
 #include <imath.hpp>
 #include <min.hpp>
 #include <print.hpp>
+#include <TryLockGuard.hpp>
 
 #include <stdint.h>
 #include <algorithm>
@@ -125,38 +126,9 @@ void LoadBalancerP2::print_P2_status(int64_t low)
     return;
 #endif
 
-  // For printing the status it is OK to use a non-blocking
-  // userspace lock because printing the status is a non
-  // essential operation and hence even if the OS preempts
-  // the thread holding the lock it won't cause any deadlocks
-  // or performance issues, it will only delay the status
-  // output.
-  struct LockGuard
-  {
-  public:
-    LockGuard(std::atomic<bool>& lock)
-      : lock_(&lock)
-    {
-      bool expected = false;
-      is_locked_ = lock.compare_exchange_weak(expected, true, std::memory_order_acquire);
-    }
-    ~LockGuard()
-    {
-      if (is_locked_)
-        lock_->store(false, std::memory_order_release);
-    }
-    bool owns_lock() const
-    {
-      return is_locked_;
-    }
-  private:
-    std::atomic<bool>* lock_ = nullptr;
-    bool is_locked_ = false;
-  };
+  TryLockGuard guard(print_lock_);
 
-  LockGuard lockGuard(print_lock_);
-
-  if (lockGuard.owns_lock())
+  if (guard.owns_lock())
   {
     next_print_time_ = time + 0.1;
     double percent = get_percent(low, sieve_limit_);

--- a/src/LoadBalancerP2.cpp
+++ b/src/LoadBalancerP2.cpp
@@ -115,6 +115,16 @@ bool LoadBalancerP2::get_work(int64_t& low, int64_t& high)
 
 void LoadBalancerP2::print_P2_status(int64_t low)
 {
+  double time = get_time();
+
+#if __cplusplus >= 201703L
+  // Prevent lock contention on many-core systems,
+  // print status only every 0.1 seconds.
+  if (std::atomic<double>::is_always_lock_free &&
+      time <= next_print_time_.load(std::memory_order_relaxed))
+    return;
+#endif
+
   // For printing the status it is OK to use a non-blocking
   // userspace lock because printing the status is a non
   // essential operation and hence even if the OS preempts
@@ -148,23 +158,16 @@ void LoadBalancerP2::print_P2_status(int64_t low)
 
   if (lockGuard.owns_lock())
   {
-    double time = get_time();
-    double old = time_;
-    double threshold = 0.1;
+    next_print_time_ = time + 0.1;
+    double percent = get_percent(low, sieve_limit_);
 
-    if ((time - old) >= threshold)
+    if (percent > percent_)
     {
-      double percent = get_percent(low, sieve_limit_);
-
-      if (percent > percent_)
-      {
-        time_ = time;
-        percent_ = percent;
-        std::string status = "Status: ";
-        status += to_string(percent, precision_);
-        status += '%';
-        print_status(status);
-      }
+      percent_ = percent;
+      std::string status = "Status: ";
+      status += to_string(percent, precision_);
+      status += '%';
+      print_status(status);
     }
   }
 }

--- a/src/LoadBalancerP2.cpp
+++ b/src/LoadBalancerP2.cpp
@@ -136,6 +136,16 @@ void LoadBalancerP2::print_P2_status(int64_t low)
 
   if (guard.owns_lock())
   {
+  #if __cplusplus >= 201703L
+    // It is theoretically possible that multiple threads
+    // enter this critical sections within 0.1 seconds.
+    // This additional condition prevents it.
+    if (std::atomic<double>::is_always_lock_free &&
+        time <= next_print_time_.load(std::memory_order_relaxed))
+      return;
+  #endif
+
+    // The next thread can print again in 0.1 seconds
     next_print_time_.store(time + 0.1, std::memory_order_relaxed);
     double percent = get_percent(low, sieve_limit_);
 

--- a/src/LoadBalancerP2.cpp
+++ b/src/LoadBalancerP2.cpp
@@ -18,7 +18,6 @@
 #include <TryLockGuard.hpp>
 
 #include <stdint.h>
-#include <algorithm>
 #include <atomic>
 #include <cmath>
 #include <string>
@@ -36,14 +35,14 @@ LoadBalancerP2::LoadBalancerP2(maxint_t x,
 {
   int64_t low = isqrt(x);
   low = min(low, sieve_limit_);
+  low_.store(low, std::memory_order_relaxed);
   int64_t dist = sieve_limit_ - low;
-  atomic_low_.store(low, std::memory_order_relaxed);
 
   // These load balancing settings work well on my
   // dual-socket AMD EPYC 7642 server with 192 CPU cores.
   min_thread_dist_ = 1 << 23;
   double max_threads = std::pow(sieve_limit_, 1 / 3.7);
-  threads = std::min(threads, (int) max_threads);
+  threads = min(threads, (int) max_threads);
   threads_ = ideal_num_threads(dist, threads, min_thread_dist_);
 
   // Using more chunks per thread improves load
@@ -61,12 +60,11 @@ int LoadBalancerP2::get_threads() const
 /// Assign new [low, high[ workload to thread.
 /// Multiple threads may call get_work() simultaneously, since
 /// this function is not protected by a mutex, it must not
-/// modify any shared member variables, except atomic_low_.
+/// modify any shared member variables, except the atomic low_.
 ///
 bool LoadBalancerP2::get_work(int64_t& low, int64_t& high)
 {
-  // Calculate the remaining sieving distance
-  low = atomic_low_.load(std::memory_order_relaxed);
+  low = low_.load(std::memory_order_relaxed);
   low = min(low, sieve_limit_);
   int64_t dist = sieve_limit_ - low;
   int64_t thread_dist = thread_dist_;
@@ -90,28 +88,27 @@ bool LoadBalancerP2::get_work(int64_t& low, int64_t& high)
     // 5x larger than the initialization time on my AMD EPYC 7642 CPU.
     double low13 = std::cbrt(low);
     int64_t low23 = (int64_t) (low13 * low13);
-    int64_t min_thread_dist = std::max(min_thread_dist_, low23);
+    int64_t min_thread_dist = max(min_thread_dist_, low23);
     thread_dist = max(min_thread_dist, thread_dist);
 
-    // Reduce the thread distance near to end to keep all
+    // Reduce thread distance near the end to keep all
     // threads busy until the computation finishes.
     int64_t max_thread_dist = dist / threads_;
     if (thread_dist > max_thread_dist)
       thread_dist = max(min_thread_dist, max_thread_dist);
   }
 
-  low = atomic_low_.fetch_add(thread_dist, std::memory_order_relaxed);
+  low = low_.fetch_add(thread_dist, std::memory_order_relaxed);
   high = low + thread_dist;
   high = min(high, sieve_limit_);
-  bool has_work = low < sieve_limit_;
 
-  // The lockfree critical section above should complete as
-  // fast as possible. Hence, printing should be done
+  // The lockfree critical section above should complete
+  // as fast as possible. Hence, printing should be done
   // afterwards since it may incur a system call.
   if (is_print_)
     print_P2_status(low);
 
-  return has_work;
+  return low < sieve_limit_;
 }
 
 void LoadBalancerP2::print_P2_status(int64_t low)

--- a/src/LoadBalancerP2.cpp
+++ b/src/LoadBalancerP2.cpp
@@ -130,7 +130,7 @@ void LoadBalancerP2::print_P2_status(int64_t low)
 
   if (guard.owns_lock())
   {
-    next_print_time_ = time + 0.1;
+    next_print_time_.store(time + 0.1, std::memory_order_relaxed);
     double percent = get_percent(low, sieve_limit_);
 
     if (percent > percent_)

--- a/src/LoadBalancerP2.hpp
+++ b/src/LoadBalancerP2.hpp
@@ -35,7 +35,6 @@ private:
   int64_t sieve_limit_ = 0;
   int64_t min_thread_dist_ = 0;
   int64_t thread_dist_ = 0;
-  double time_ = 0;
   double percent_ = -1;
   int threads_ = 0;
   int precision_ = 0;
@@ -43,6 +42,7 @@ private:
   MAYBE_UNUSED char pad1[MAX_CACHE_LINE_SIZE];
   std::atomic<int64_t> atomic_low_;
   MAYBE_UNUSED char pad2[MAX_CACHE_LINE_SIZE];
+  std::atomic<double> next_print_time_{0};
   std::atomic<bool> print_lock_{false};
   MAYBE_UNUSED char pad3[MAX_CACHE_LINE_SIZE];
 };

--- a/src/LoadBalancerP2.hpp
+++ b/src/LoadBalancerP2.hpp
@@ -17,8 +17,8 @@
 #include <int128_t.hpp>
 #include <macros.hpp>
 
-#include <atomic>
 #include <stdint.h>
+#include <atomic>
 
 namespace primecount {
 
@@ -39,8 +39,9 @@ private:
   int threads_ = 0;
   int precision_ = 0;
   bool is_print_ = false;
+
   MAYBE_UNUSED char pad1[MAX_CACHE_LINE_SIZE];
-  std::atomic<int64_t> atomic_low_;
+  std::atomic<int64_t> low_{0};
   MAYBE_UNUSED char pad2[MAX_CACHE_LINE_SIZE];
   std::atomic<double> next_print_time_{0};
   std::atomic<bool> print_lock_{false};

--- a/src/LoadBalancerP2.hpp
+++ b/src/LoadBalancerP2.hpp
@@ -4,7 +4,7 @@
 ///        computation of the 2nd partial sieve function.
 ///        It is used by the P2(x, a) and B(x, y) functions.
 ///
-/// Copyright (C) 2025 Kim Walisch, <kim.walisch@gmail.com>
+/// Copyright (C) 2026 Kim Walisch, <kim.walisch@gmail.com>
 ///
 /// This file is distributed under the BSD License. See the COPYING
 /// file in the top level directory.
@@ -13,11 +13,12 @@
 #ifndef LOADBALANCERP2_HPP
 #define LOADBALANCERP2_HPP
 
+#include <primecount-config.hpp>
 #include <int128_t.hpp>
-#include <OmpLock.hpp>
+#include <macros.hpp>
 
+#include <atomic>
 #include <stdint.h>
-#include <string>
 
 namespace primecount {
 
@@ -29,16 +30,21 @@ public:
   int get_threads() const;
 
 private:
-  std::string get_status();
-  int64_t low_ = 0;
+  void print_P2_status(int64_t low);
+
   int64_t sieve_limit_ = 0;
   int64_t min_thread_dist_ = 0;
   int64_t thread_dist_ = 0;
   double time_ = 0;
+  double percent_ = -1;
   int threads_ = 0;
   int precision_ = 0;
   bool is_print_ = false;
-  OmpLock lock_;
+  MAYBE_UNUSED char pad1[MAX_CACHE_LINE_SIZE];
+  std::atomic<int64_t> atomic_low_;
+  MAYBE_UNUSED char pad2[MAX_CACHE_LINE_SIZE];
+  std::atomic<bool> print_lock_{false};
+  MAYBE_UNUSED char pad3[MAX_CACHE_LINE_SIZE];
 };
 
 } // namespace

--- a/src/gourdon/AC.cpp
+++ b/src/gourdon/AC.cpp
@@ -866,7 +866,6 @@ T AC_OpenMP(T x,
   int max_threads = (int) std::pow(xz, 1 / 3.7);
   threads = min(threads, max_threads);
   threads = ideal_num_threads(x13, threads, thread_threshold);
-  LoadBalancerAC loadBalancer(sqrtx, y, threads, is_print);
 
   // Initialize libdivide vector from primes vector
   Vector<libdivide::branchfree_divider<uint64_t>> lprimes;
@@ -885,6 +884,7 @@ T AC_OpenMP(T x,
   int64_t pi_root3_xy = pi[iroot<3>(xy)];
   int64_t pi_root3_xz = pi[iroot<3>(xz)];
   RelaxedAtomic<int64_t> min_c1(max(k, pi_root3_xz) + 1);
+  LoadBalancerAC loadBalancer(sqrtx, y, threads, is_print);
 
   // In order to reduce the thread creation & destruction
   // overhead we reuse the same threads throughout the

--- a/src/gourdon/LoadBalancerAC.cpp
+++ b/src/gourdon/LoadBalancerAC.cpp
@@ -71,8 +71,6 @@ LoadBalancerAC::LoadBalancerAC(int64_t sqrtx,
   // Limit to 2^31-1 to allow bit packing into uint64_t
   segments = min(segments, INT32_MAX);
   segment_size = min(segment_size, INT32_MAX);
-  max_segment_size_ = min(max_segment_size_, INT32_MAX);
-
   segment_size = max(min_segment_size, segment_size);
   segment_size = SegmentedPiTable::align_segment_size(segment_size);
   max_segment_size_ = max(L1_segment_size, segment_size);

--- a/src/gourdon/LoadBalancerAC.cpp
+++ b/src/gourdon/LoadBalancerAC.cpp
@@ -79,10 +79,16 @@ LoadBalancerAC::LoadBalancerAC(int64_t sqrtx,
   max_segment_size_ = SegmentedPiTable::align_segment_size(max_segment_size_);
 
   store_packed(segment_size, segments);
-  ThreadDataAC thread{ 0, segment_size, segments, 0 };
 
   if (is_print_)
+  {
+    ThreadDataAC thread;
+    thread.low = 0;
+    thread.segment_size = segment_size;
+    thread.segments = segments;
+    thread.secs = 0;
     print_AC_status(thread, start_time_);
+  }
 }
 
 /// Pack segment_size & segments into a uint64_t,

--- a/src/gourdon/LoadBalancerAC.cpp
+++ b/src/gourdon/LoadBalancerAC.cpp
@@ -157,6 +157,9 @@ bool LoadBalancerAC::get_work(ThreadDataAC& thread)
     store_packed(segment_size, segments);
   }
 
+  // The earlier loads are used for heuristic chunk
+  // sizing, it is OK if they are slightly outdated. This
+  // fetch_add() reserves unique work for this thread.
   int64_t thread_dist = segment_size * segments;
   low = low_.fetch_add(thread_dist, std::memory_order_relaxed);
 

--- a/src/gourdon/LoadBalancerAC.cpp
+++ b/src/gourdon/LoadBalancerAC.cpp
@@ -19,9 +19,12 @@
 #include <primecount-config.hpp>
 #include <primecount-internal.hpp>
 #include <imath.hpp>
+#include <min.hpp>
+#include <print.hpp>
+#include <TryLockGuard.hpp>
 
 #include <stdint.h>
-#include <algorithm>
+#include <atomic>
 #include <string>
 
 namespace primecount {
@@ -32,11 +35,17 @@ LoadBalancerAC::LoadBalancerAC(int64_t sqrtx,
                                bool is_print) :
   sqrtx_(sqrtx),
   y_(y),
+  start_time_(get_time()),
   threads_(threads),
   is_print_(is_print)
 {
-  lock_.init(threads);
+  // When using multi-threading we use a tiny segment
+  // size of x^(1/4). This segment fits into the CPU's
+  // cache and ensures good load balancing i.e. the
+  // work is evenly distributed amongst all CPU cores.
   int64_t x14 = isqrt(sqrtx);
+  int64_t segment_size = x14;
+  int64_t segments = 1;
 
   // Minimum segment size = 512 bytes.
   // This size performs well near 1e16 on my AMD EPYC 2.
@@ -53,129 +62,159 @@ LoadBalancerAC::LoadBalancerAC(int64_t sqrtx,
     // When using a single thread we can use a segment
     // size larger than x^(1/4) because load balancing
     // is only needed for multi-threading.
-    segment_size_ = std::max(x14, L1_segment_size);
+    segment_size = max(x14, L1_segment_size);
 
-    // When status printing is enabled (and threads = 1)
-    // we start with a single segment and then gradually
-    // increase the number of segments. This way we can
-    // regularly print status updates.
-    if (is_print)
-      segments_ = 1;
-    else
-      segments_ = ceil_div(sqrtx, segment_size_);
-  }
-  else
-  {
-    // When using multi-threading we use a tiny segment
-    // size of x^(1/4). This segment fits into the CPU's
-    // cache and ensures good load balancing i.e. the
-    // work is evenly distributed amongst all CPU cores.
-    segment_size_ = x14;
-    segments_ = 1;
+    if (!is_print)
+      segments = ceil_div(sqrtx, segment_size);
   }
 
-  segment_size_ = std::max(min_segment_size, segment_size_);
-  segment_size_ = SegmentedPiTable::align_segment_size(segment_size_);
-  max_segment_size_ = std::max(L1_segment_size, segment_size_);
+  // Limit to 2^31-1 to allow bit packing into uint64_t
+  segments = min(segments, INT32_MAX);
+  segment_size = min(segment_size, INT32_MAX);
+  max_segment_size_ = min(max_segment_size_, INT32_MAX);
+
+  segment_size = max(min_segment_size, segment_size);
+  segment_size = SegmentedPiTable::align_segment_size(segment_size);
+  max_segment_size_ = max(L1_segment_size, segment_size);
   max_segment_size_ = SegmentedPiTable::align_segment_size(max_segment_size_);
 
+  store_packed(segment_size, segments);
+  ThreadDataAC thread{ 0, segment_size, segments, 0 };
+
   if (is_print_)
-  {
-    double time = get_time();
-    std::string status = get_status(time);
-    if (!status.empty())
-      print_status(status);
-  }
+    print_AC_status(thread, start_time_);
 }
 
+/// Pack segment_size & segments into a uint64_t,
+/// needed for lockfree atomic data access.
+///
+void LoadBalancerAC::store_packed(int64_t segment_size,
+                                  int64_t segments)
+{
+  ASSERT(segments <= INT32_MAX);
+  ASSERT(segment_size <= INT32_MAX);
+  uint64_t packed = segment_size | (segments << 32);
+  segment_data_.store(packed, std::memory_order_relaxed);
+}
+
+/// Assign new [low, high[ workload to thread.
+/// Multiple threads may call get_work() simultaneously, since
+/// this function is not protected by a mutex, it must not
+/// modify any shared member variables, except the atomic low_
+/// and segment_data_ variables.
+///
 bool LoadBalancerAC::get_work(ThreadDataAC& thread)
 {
   double time = get_time();
   thread.secs = time - thread.secs;
-  std::string status;
-  bool has_work;
+  int64_t low = low_.load(std::memory_order_relaxed);
 
+  if (low >= sqrtx_)
+    return false;
+
+  int64_t remaining_dist = sqrtx_ - low;
+  double total_secs = time - start_time_;
+  double increase_threshold = max(0.01, total_secs / 1000);
+  uint64_t segment_data = segment_data_.load(std::memory_order_relaxed);
+  int64_t segment_size = segment_data & 0xffffffffu;
+  int64_t segments = segment_data >> 32;
+
+  // Near the end of the computation we use a smaller
+  // increase_threshold <= 1 second in order to make sure
+  // all threads finish nearly at same time.
+  if (segment_size == max_segment_size_)
+    increase_threshold = min(increase_threshold, 1.0);
+
+  // Most special leaves are below y (~ x^(1/3) * log(x)).
+  // We make sure this interval is evenly distributed
+  // amongst all threads by using a small segment size.
+  // Above y we increase the segment size (or the number of
+  // segments) by 2x if the thread runtime is close to 0.
+  if (low > y_ &&
+      thread.secs < increase_threshold &&
+      thread.segments >= segments &&
+      thread.segment_size >= segment_size &&
+      segment_size * segments * (threads_ * 8) < remaining_dist)
   {
-    LockGuard lockGuard(lock_);
+    int64_t increase_factor = 2;
 
-    if (low_ >= sqrtx_)
-      return false;
-    if (low_ == 0)
-      start_time_ = time;
-
-    int64_t remaining_dist = sqrtx_ - low_;
-    double total_secs = time - start_time_;
-    double increase_threshold = std::max(0.01, total_secs / 1000);
-
-    // Near the end of the computation we use a smaller
-    // increase_threshold <= 1 second in order to make sure
-    // all threads finish nearly at same time.
-    if (segment_size_ == max_segment_size_)
-      increase_threshold = std::min(increase_threshold, 1.0);
-
-    // Most special leaves are below y (~ x^(1/3) * log(x)).
-    // We make sure this interval is evenly distributed
-    // amongst all threads by using a small segment size.
-    // Above y we increase the segment size (or the number of
-    // segments) by 2x if the thread runtime is close to 0.
-    if (low_ > y_ &&
-        thread.secs < increase_threshold &&
-        thread.segments == segments_ &&
-        thread.segment_size == segment_size_ &&
-        segment_size_ * segments_ * (threads_ * 8) < remaining_dist)
+    if (segment_size >= max_segment_size_)
     {
-      int64_t increase_factor = 2;
-
-      if (segment_size_ >= max_segment_size_)
-        segments_ *= increase_factor;
-      else
-      {
-        segment_size_ = segment_size_ * increase_factor;
-        segment_size_ = std::min(segment_size_, max_segment_size_);
-        segment_size_ = SegmentedPiTable::align_segment_size(segment_size_);
-      }
+      segments *= increase_factor;
+      segments = min(segments, INT32_MAX);
+    }
+    else
+    {
+      segment_size = segment_size * increase_factor;
+      segment_size = min(segment_size, max_segment_size_);
+      segment_size = SegmentedPiTable::align_segment_size(segment_size);
     }
 
-    if (is_print_)
-      status = get_status(time);
-
-    thread.low = low_;
-    thread.segments = segments_;
-    thread.segment_size = segment_size_;
-    has_work = thread.low < sqrtx_;
-    low_ = std::min(low_ + segment_size_ * segments_, sqrtx_);
-    segment_nr_++;
+    store_packed(segment_size, segments);
   }
 
-  // Printing to the terminal incurs a system call
-  // and may hence be slow. Therefore, we do it
-  // after having released the mutex.
-  if (!status.empty())
-    print_status(status);
+  int64_t thread_dist = segment_size * segments;
+  low = low_.fetch_add(thread_dist, std::memory_order_relaxed);
 
-  return has_work;
+  thread.low = low;
+  thread.segments = segments;
+  thread.segment_size = segment_size;
+
+  // The lockfree critical section above should complete
+  // as fast as possible. Hence, printing should be done
+  // afterwards since it may incur a system call.
+  if (is_print_)
+    print_AC_status(thread, time);
+
+  return thread.low < sqrtx_;
 }
 
-std::string LoadBalancerAC::get_status(double time)
+void LoadBalancerAC::print_AC_status(const ThreadDataAC& thread,
+                                     double time)
 {
-  double threshold = 0.1;
+  int64_t segment_nr = segment_nr_.fetch_add(1, std::memory_order_relaxed);
 
-  if (time - print_time_ >= threshold)
+#if __cplusplus >= 201703L
+  // Prevent lock contention on many-core systems,
+  // print status only every 0.1 seconds.
+  if (std::atomic<double>::is_always_lock_free &&
+      time <= next_print_time_.load(std::memory_order_relaxed))
+    return;
+#endif
+
+  // For printing the status it is OK to use a non-blocking
+  // userspace lock because printing the status is a non
+  // essential operation and hence even if the OS preempts
+  // the thread holding the lock it won't cause any deadlocks
+  // or performance issues, it will only delay the status
+  // output.
+  TryLockGuard guard(print_lock_);
+
+  if (guard.owns_lock())
   {
-    print_time_ = time;
+  #if __cplusplus >= 201703L
+    // It is theoretically possible that multiple threads
+    // enter this critical sections within 0.1 seconds.
+    // This additional condition prevents it.
+    if (std::atomic<double>::is_always_lock_free &&
+        time <= next_print_time_.load(std::memory_order_relaxed))
+      return;
+  #endif
 
-    int64_t remaining_dist = sqrtx_ - low_;
-    int64_t thread_dist = segment_size_ * segments_;
+    // The next thread can print again in 0.1 seconds
+    next_print_time_.store(time + 0.1, std::memory_order_relaxed);
+
+    segment_nr += 1;
+    int64_t remaining_dist = sqrtx_ - thread.low;
+    int64_t thread_dist = thread.segment_size * thread.segments;
     int64_t total_segments = ceil_div(remaining_dist, thread_dist);
-    total_segments += segment_nr_;
+    total_segments += segment_nr;
 
     std::string status = "Segments: ";
-    status += std::to_string(segment_nr_) + '/';
+    status += std::to_string(segment_nr) + '/';
     status += std::to_string(total_segments);
-    return status;
+    print_status(status);
   }
-
-  return std::string();
 }
 
 } // namespace

--- a/src/gourdon/LoadBalancerAC.cpp
+++ b/src/gourdon/LoadBalancerAC.cpp
@@ -163,14 +163,15 @@ bool LoadBalancerAC::get_work(ThreadDataAC& thread)
   thread.low = low;
   thread.segments = segments;
   thread.segment_size = segment_size;
+  bool has_work = low < sqrtx_;
 
   // The lockfree critical section above should complete
   // as fast as possible. Hence, printing should be done
   // afterwards since it may incur a system call.
-  if (is_print_)
+  if (is_print_ && has_work)
     print_AC_status(thread, time);
 
-  return thread.low < sqrtx_;
+  return has_work;
 }
 
 void LoadBalancerAC::print_AC_status(const ThreadDataAC& thread,

--- a/src/gourdon/LoadBalancerAC.cpp
+++ b/src/gourdon/LoadBalancerAC.cpp
@@ -209,7 +209,6 @@ void LoadBalancerAC::print_AC_status(const ThreadDataAC& thread,
     // The next thread can print again in 0.1 seconds
     next_print_time_.store(time + 0.1, std::memory_order_relaxed);
 
-    segment_nr += 1;
     int64_t remaining_dist = sqrtx_ - thread.low;
     int64_t thread_dist = thread.segment_size * thread.segments;
     int64_t total_segments = ceil_div(remaining_dist, thread_dist);

--- a/src/gourdon/LoadBalancerAC.hpp
+++ b/src/gourdon/LoadBalancerAC.hpp
@@ -7,7 +7,7 @@
 ///        Load balancing is described in more detail at:
 ///        https://github.com/kimwalisch/primecount/blob/master/doc/Easy-Special-Leaves.pdf
 ///
-/// Copyright (C) 2025 Kim Walisch, <kim.walisch@gmail.com>
+/// Copyright (C) 2026 Kim Walisch, <kim.walisch@gmail.com>
 ///
 /// This file is distributed under the BSD License. See the COPYING
 /// file in the top level directory.
@@ -16,10 +16,11 @@
 #ifndef LOADBALANCERAC_HPP
 #define LOADBALANCERAC_HPP
 
-#include <OmpLock.hpp>
+#include <primecount-config.hpp>
+#include <macros.hpp>
 
 #include <stdint.h>
-#include <string>
+#include <atomic>
 
 namespace primecount {
 
@@ -38,19 +39,25 @@ public:
   bool get_work(ThreadDataAC& thread);
 
 private:
-  std::string get_status(double current_time);
-  int64_t low_ = 0;
+  void store_packed(int64_t segment_size, int64_t segments);
+  void print_AC_status(const ThreadDataAC& thread, double time);
+
   int64_t sqrtx_ = 0;
   int64_t y_ = 0;
-  int64_t segments_ = 0;
-  int64_t segment_size_ = 0;
-  int64_t segment_nr_ = 0;
   int64_t max_segment_size_ = 0;
   double start_time_ = 0;
-  double print_time_ = 0;
   int threads_ = 0;
   bool is_print_ = false;
-  OmpLock lock_;
+
+  MAYBE_UNUSED char pad1[MAX_CACHE_LINE_SIZE];
+  std::atomic<int64_t> low_{0};
+  std::atomic<uint64_t> segment_data_{0};
+  MAYBE_UNUSED char pad2[MAX_CACHE_LINE_SIZE];
+  std::atomic<int64_t> segment_nr_{-1};
+  MAYBE_UNUSED char pad3[MAX_CACHE_LINE_SIZE];
+  std::atomic<double> next_print_time_{0};
+  std::atomic<bool> print_lock_{false};
+  MAYBE_UNUSED char pad4[MAX_CACHE_LINE_SIZE];
 };
 
 } // namespace

--- a/src/gourdon/LoadBalancerAC.hpp
+++ b/src/gourdon/LoadBalancerAC.hpp
@@ -53,7 +53,7 @@ private:
   std::atomic<int64_t> low_{0};
   std::atomic<uint64_t> segment_data_{0};
   MAYBE_UNUSED char pad2[MAX_CACHE_LINE_SIZE];
-  std::atomic<int64_t> segment_nr_{-1};
+  std::atomic<int64_t> segment_nr_{0};
   MAYBE_UNUSED char pad3[MAX_CACHE_LINE_SIZE];
   std::atomic<double> next_print_time_{0};
   std::atomic<bool> print_lock_{false};


### PR DESCRIPTION
On large `c8a.metal-48xl` AWS instances using 192 AMD Zen5 CPU cores I noticed that when primecount was compiled using LLVM/Clang the performance of short computations was very bad due to high mutex contention in the thread load balancers.

This merge request converts two (out of 3 total) thread load balancers to a lockfree design using `std::atomic` which greatly improves performance of short computations on the `c8a.metal-48xl` AWS instance using LLVM/Clang.