### PR TITLE
Convert LoadBalancerS2 to lockfree design

### DIFF
--- a/src/LoadBalancerS2.cpp
+++ b/src/LoadBalancerS2.cpp
@@ -189,8 +189,8 @@ bool LoadBalancerS2::get_work(ThreadData& thread)
   int64_t dist = thread.segment_size * thread.segments;
   thread.low = low_.fetch_add(dist, std::memory_order_relaxed);
   thread.sum = 0;
-  thread.secs = 0;
   thread.init_secs = 0;
+  thread.secs = 0;
 
   // The lockfree critical section above should complete
   // as fast as possible. Hence, printing should be done

--- a/src/LoadBalancerS2.cpp
+++ b/src/LoadBalancerS2.cpp
@@ -141,44 +141,53 @@ void LoadBalancerS2::store_packed(uint64_t segment_size,
 ///
 bool LoadBalancerS2::get_work(ThreadData& thread)
 {
-  int64_t print_high = 0;
+  bool has_run_load_balancing = false;
   int64_t max_low = max_low_.load(std::memory_order_relaxed);
-  bool found_first_leaf = found_first_leaf_.load(std::memory_order_relaxed);
   uint64_t segment_data = segment_data_.load(std::memory_order_relaxed);
   int64_t segment_size = segment_data & 0xffffffffu;
   int64_t segments = segment_data >> 32;
+  int64_t print_high = 0;
 
-  if (thread.sum &&
-      !found_first_leaf)
+  if (thread.low > max_low)
   {
-    found_first_leaf_.store(true, std::memory_order_relaxed);
-    found_first_leaf = true;
+    // Try setting max_low_ = thread.low
+    has_run_load_balancing = max_low_.compare_exchange_strong(
+        max_low, thread.low, std::memory_order_relaxed,
+        std::memory_order_relaxed);
+
+    if (has_run_load_balancing)
+    {
+      if (is_print_)
+      {
+        int64_t dist = thread.segment_size * thread.segments;
+        print_high = thread.low + dist;
+      }
+
+      bool found_first_leaf = found_first_leaf_.load(
+          std::memory_order_relaxed);
+
+      if (thread.sum && !found_first_leaf)
+      {
+        found_first_leaf_.store(true, std::memory_order_relaxed);
+        found_first_leaf = true;
+      }
+
+      // We only start increasing the segment size and segments
+      // per thread once the first special leaf has been found.
+      // Most special leaves are located near the start (near y).
+      // Hence, we assign tiny work chunks to the threads in
+      // this region to avoid load imbalance.
+      if (found_first_leaf)
+        run_load_balancing(thread, segment_size);
+      else
+        has_run_load_balancing = false;
+    }
   }
 
-  if (thread.low <= max_low)
+  if (!has_run_load_balancing)
   {
     thread.segment_size = segment_size;
     thread.segments = segments;
-  }
-  else // thread.low > max_low
-  {
-    max_low_.store(thread.low, std::memory_order_relaxed);
-
-    if (is_print_)
-      print_high = thread.low + thread.segment_size * thread.segments;
-
-    // We only start increasing the segment size and segments
-    // per thread once the first special leaf has been found.
-    // Most special leaves are located near the start (near y).
-    // Hence, we assign tiny work chunks to the threads in
-    // this region to avoid load imbalance.
-    if (found_first_leaf)
-      run_load_balancing(thread, segment_size);
-    else
-    {
-      thread.segment_size = segment_size;
-      thread.segments = segments;
-    }
   }
 
   // The earlier loads are used for heuristic chunk

--- a/src/LoadBalancerS2.cpp
+++ b/src/LoadBalancerS2.cpp
@@ -200,8 +200,6 @@ bool LoadBalancerS2::get_work(ThreadData& thread)
 void LoadBalancerS2::run_load_balancing(ThreadData& thread,
                                         int64_t segment_size)
 {
-  int64_t segments = thread.segments;
-
   // If segment_size < L1_segment_size then slowly increase
   // the segment size until it reaches L1_segment_size.
   if (segment_size < L1_segment_size)
@@ -211,9 +209,8 @@ void LoadBalancerS2::run_load_balancing(ThreadData& thread,
     segment_size = min(segment_size, max_packed_segment_size);
     segment_size = Sieve::align_segment_size(segment_size);
 
-    store_packed(segment_size, segments);
+    store_packed(segment_size, thread.segments);
     thread.segment_size = segment_size;
-    thread.segments = segments;
     return;
   }
 
@@ -228,14 +225,13 @@ void LoadBalancerS2::run_load_balancing(ThreadData& thread,
     segment_size = min(segment_size, max_packed_segment_size);
     segment_size = Sieve::align_segment_size(segment_size);
 
-    store_packed(segment_size, segments);
+    store_packed(segment_size, thread.segments);
     thread.segment_size = segment_size;
-    thread.segments = segments;
     return;
   }
 
   int64_t low = low_.load(std::memory_order_relaxed);
-  segments = update_number_of_segments(segments, low, thread);
+  int64_t segments = get_segments(thread, low);
 
   // The hard special leaves algorithm is basically a modified
   // segmented sieve of Eratosthenes. Using the segmented sieve of
@@ -275,9 +271,8 @@ void LoadBalancerS2::run_load_balancing(ThreadData& thread,
 /// Increase or decrease the number of segments per
 /// thread based on the remaining runtime.
 ///
-int64_t LoadBalancerS2::update_number_of_segments(int64_t segments,
-                                                  int64_t low,
-                                                  const ThreadData& thread) const
+int64_t LoadBalancerS2::get_segments(const ThreadData& thread,
+                                     int64_t low) const
 {
   // Near the end it is important that threads run only for
   // a short amount of time in order to ensure that all
@@ -343,6 +338,7 @@ int64_t LoadBalancerS2::update_number_of_segments(int64_t segments,
   // identical.
   factor = in_between(0.5, factor, 2.0);
   double next_runtime = thread.secs * factor;
+  int64_t segments = thread.segments;
 
   if (next_runtime < min_secs)
     segments *= 2;

--- a/src/LoadBalancerS2.cpp
+++ b/src/LoadBalancerS2.cpp
@@ -54,8 +54,11 @@ namespace {
 // size but smaller than the L2 cache size (per core).
 
 constexpr int64_t numbers_per_byte = 30;
+constexpr int64_t segment_size_alignment = 240;
 constexpr int64_t L1_segment_size = L1_CACHE_SIZE * numbers_per_byte;
 constexpr int64_t L2_segment_size = L2_CACHE_SIZE * numbers_per_byte;
+constexpr int64_t max_packed_segment_size =
+    INT32_MAX - (INT32_MAX % segment_size_alignment);
 
 } // namespace
 
@@ -73,19 +76,23 @@ LoadBalancerS2::LoadBalancerS2(maxint_t x,
   is_print_(is_print),
   status_(x, y, is_print)
 {
+  int64_t segment_size;
+  int64_t segments;
+
   if (threads == 1 &&
       !is_print)
   {
-    segment_size_ = L1_segment_size;
-    segment_size_ = min(segment_size_, sieve_limit);
-    segment_size_ = Sieve::align_segment_size(segment_size_);
+    segment_size = L1_segment_size;
+    segment_size = min(segment_size, sieve_limit);
+    segment_size = min(segment_size, max_packed_segment_size);
+    segment_size = Sieve::align_segment_size(segment_size);
 
     // Currently our Sieve.cpp does not rebalance its
     // counters data structure. However, if we process the
     // computation in chunks then the sieve gets recreated
     // for each new chunk which rebalances the counters.
     // Therefore we limit the number of segments here.
-    segments_ = 100;
+    segments = 100;
   }
   else
   {
@@ -94,11 +101,15 @@ LoadBalancerS2::LoadBalancerS2(maxint_t x,
     // special leaves are located in the first few segments
     // and as we need to ensure that all threads are
     // assigned an equal amount of work.
-    segment_size_ = isqrt(isqrt(x));
-    segment_size_ = max(segment_size_, 1 << 9);
-    segment_size_ = Sieve::align_segment_size(segment_size_);
-    segments_ = 1;
+    maxint_t x14 = isqrt(isqrt(x));
+    segment_size = (x14 > max_packed_segment_size) ?
+        max_packed_segment_size : (int64_t) x14;
+    segment_size = max(segment_size, (int64_t) 1 << 9);
+    segment_size = Sieve::align_segment_size(segment_size);
+    segments = 1;
   }
+
+  store_packed(segment_size, segments);
 }
 
 /// Pack segment_size & segments into a uint64_t,
@@ -109,8 +120,23 @@ void LoadBalancerS2::store_packed(int64_t segment_size,
 {
   ASSERT(segments <= INT32_MAX);
   ASSERT(segment_size <= INT32_MAX);
-  uint64_t packed = segment_size | (segments << 32);
+  uint64_t packed = (uint64_t) segment_size | ((uint64_t) segments << 32);
   segment_data_.store(packed, std::memory_order_relaxed);
+}
+
+bool LoadBalancerS2::update_max_low(int64_t low)
+{
+  int64_t max_low = max_low_.load(std::memory_order_relaxed);
+
+  while (low > max_low)
+  {
+    if (max_low_.compare_exchange_weak(max_low, low,
+                                       std::memory_order_relaxed,
+                                       std::memory_order_relaxed))
+      return true;
+  }
+
+  return false;
 }
 
 /// Remaining seconds till finished
@@ -127,6 +153,7 @@ bool LoadBalancerS2::get_work(ThreadData& thread)
 {
   int64_t prev_thread_high = 0;
   bool found_first_leaf = found_first_leaf_.load(std::memory_order_relaxed);
+  bool updated_segment_data = false;
 
   if (thread.sum && !found_first_leaf)
   {
@@ -134,7 +161,7 @@ bool LoadBalancerS2::get_work(ThreadData& thread)
     found_first_leaf_.store(true, std::memory_order_relaxed);
   }
 
-  if (thread.low > max_low_)
+  if (update_max_low(thread.low))
   {
     if (is_print_)
     {
@@ -148,13 +175,26 @@ bool LoadBalancerS2::get_work(ThreadData& thread)
     // Hence, we assign tiny work chunks to the threads in this
     // region to avoid load imbalance.
     if (found_first_leaf)
+    {
       update_load_balancing(thread);
+      updated_segment_data = true;
+    }
   }
-  else
+
+  if (!updated_segment_data)
   {
     uint64_t segment_data = segment_data_.load(std::memory_order_relaxed);
     thread.segment_size = segment_data & 0xffffffffu;
     thread.segments = segment_data >> 32;
+  }
+
+  int64_t low = low_.load(std::memory_order_relaxed);
+  if (low >= sieve_limit_)
+  {
+    if (prev_thread_high)
+      print_S2_status(prev_thread_high);
+
+    return false;
   }
 
   int64_t thread_dist = thread.segment_size * thread.segments;
@@ -165,28 +205,15 @@ bool LoadBalancerS2::get_work(ThreadData& thread)
 
   // Printing to the terminal incurs a system call
   // and may hence be slow. Therefore, we do it
-  // after having released the mutex.
+  // after the lockfree work assignment.
   if (prev_thread_high)
-  {
-    double percent = status_.getStatus(prev_thread_high, sieve_limit_);
-    if (percent != 0)
-    {
-      TryLockGuard guard(print_lock_);
-      if (guard.owns_lock())
-      {
-        double percent = status_.getStatus(prev_thread_high, sieve_limit_);
-        status_.print(percent);
-      }
-    }
-  }
+    print_S2_status(prev_thread_high);
 
   return thread.low < sieve_limit_;
 }
 
 void LoadBalancerS2::update_load_balancing(ThreadData& thread)
 {
-  max_low_ = thread.low;
-
   int64_t segments = thread.segments;
   int64_t segment_data = segment_data_.load(std::memory_order_relaxed);
   int64_t segment_size = segment_data & 0xffffffffu;
@@ -197,6 +224,7 @@ void LoadBalancerS2::update_load_balancing(ThreadData& thread)
   {
     segment_size += segment_size / 16;
     segment_size = min(segment_size, L1_segment_size);
+    segment_size = min(segment_size, max_packed_segment_size);
     segment_size = Sieve::align_segment_size(segment_size);
 
     store_packed(segment_size, segments);
@@ -213,6 +241,7 @@ void LoadBalancerS2::update_load_balancing(ThreadData& thread)
   {
     segment_size += segment_size / 16;
     segment_size = min(segment_size, L2_segment_size);
+    segment_size = min(segment_size, max_packed_segment_size);
     segment_size = Sieve::align_segment_size(segment_size);
 
     store_packed(segment_size, segments);
@@ -250,6 +279,7 @@ void LoadBalancerS2::update_load_balancing(ThreadData& thread)
       dist = (segment_size * segments) * threads_;
       high = min(low + dist, sieve_limit_);
       segment_size = isqrt(high);
+      segment_size = min(segment_size, max_packed_segment_size);
       segment_size = Sieve::align_segment_size(segment_size);
     }
   }
@@ -340,7 +370,48 @@ int64_t LoadBalancerS2::update_number_of_segments(int64_t segments,
     segments = max(segments, 1);
   }
 
+  segments = min(segments, (int64_t) INT32_MAX);
   return segments;
+}
+
+void LoadBalancerS2::print_S2_status(int64_t low)
+{
+  double time = get_time();
+
+#if __cplusplus >= 201703L
+  // Prevent lock contention on many-core systems,
+  // print status only every 0.1 seconds.
+  if (std::atomic<double>::is_always_lock_free &&
+      time <= next_print_time_.load(std::memory_order_relaxed))
+    return;
+#endif
+
+  // For printing the status it is OK to use a non-blocking
+  // userspace lock because printing the status is a non
+  // essential operation and hence even if the OS preempts
+  // the thread holding the lock it won't cause any deadlocks
+  // or performance issues, it will only delay the status
+  // output.
+  TryLockGuard guard(print_lock_);
+
+  if (guard.owns_lock())
+  {
+  #if __cplusplus >= 201703L
+    // It is theoretically possible that multiple threads
+    // enter this critical section within 0.1 seconds.
+    // This additional condition prevents it.
+    if (std::atomic<double>::is_always_lock_free &&
+        time <= next_print_time_.load(std::memory_order_relaxed))
+      return;
+  #endif
+
+    // The next thread can print again in 0.1 seconds.
+    next_print_time_.store(time + 0.1, std::memory_order_relaxed);
+
+    double percent = status_.getStatus(low, sieve_limit_);
+    if (percent >= 0)
+      status_.print(percent);
+  }
 }
 
 } // namespace

--- a/src/LoadBalancerS2.cpp
+++ b/src/LoadBalancerS2.cpp
@@ -39,8 +39,11 @@
 #include <imath.hpp>
 #include <int128_t.hpp>
 #include <min.hpp>
+#include <TryLockGuard.hpp>
 
 #include <stdint.h>
+#include <atomic>
+#include <cmath>
 
 namespace {
 
@@ -65,13 +68,11 @@ LoadBalancerS2::LoadBalancerS2(maxint_t x,
                                bool is_print) :
   sieve_limit_(sieve_limit),
   sqrt_limit_(isqrt(sieve_limit)),
-  time_(get_time()),
+  start_time_(get_time()),
   threads_(threads),
   is_print_(is_print),
   status_(x, y, is_print)
 {
-  lock_.init(threads);
-
   if (threads == 1 &&
       !is_print)
   {
@@ -100,129 +101,177 @@ LoadBalancerS2::LoadBalancerS2(maxint_t x,
   }
 }
 
-bool LoadBalancerS2::get_work(ThreadData& thread)
+/// Pack segment_size & segments into a uint64_t,
+/// needed for lockfree atomic data access.
+///
+void LoadBalancerS2::store_packed(int64_t segment_size,
+                                  int64_t segments)
 {
-  bool has_work;
-  double status = -1;
-
-  {
-    LockGuard lockGuard(lock_);
-
-    if (thread.sum != 0)
-      found_first_leaf_ = true;
-
-    if (is_print_ &&
-        thread.low > max_low_)
-    {
-      uint64_t dist = thread.segment_size * thread.segments;
-      uint64_t high = thread.low + dist;
-      status = status_.getStatus(high, sieve_limit_);
-    }
-
-    update_load_balancing(thread);
-
-    thread.low = low_;
-    thread.segments = segments_;
-    thread.segment_size = segment_size_;
-    thread.sum = 0;
-    thread.secs = 0;
-    thread.init_secs = 0;
-
-    has_work = thread.low < sieve_limit_;
-    low_ += segment_size_ * segments_;
-  }
-
-  // Printing to the terminal incurs a system call
-  // and may hence be slow. Therefore, we do it
-  // after having released the mutex.
-  if (status >= 0)
-    status_.print(status);
-
-  return has_work;
+  ASSERT(segments <= INT32_MAX);
+  ASSERT(segment_size <= INT32_MAX);
+  uint64_t packed = segment_size | (segments << 32);
+  segment_data_.store(packed, std::memory_order_relaxed);
 }
 
-void LoadBalancerS2::update_load_balancing(const ThreadData& thread)
+/// Remaining seconds till finished
+double LoadBalancerS2::remaining_secs(int64_t low) const
 {
+  double percent = status_.getPercent(low, sieve_limit_);
+  percent = in_between(10, percent, 100);
+  double total_secs = get_time() - start_time_;
+  double secs = total_secs * (100 / percent) - total_secs;
+  return secs;
+}
+
+bool LoadBalancerS2::get_work(ThreadData& thread)
+{
+  int64_t prev_thread_high = 0;
+  bool found_first_leaf = found_first_leaf_.load(std::memory_order_relaxed);
+
+  if (thread.sum && !found_first_leaf)
+  {
+    found_first_leaf = true;
+    found_first_leaf_.store(true, std::memory_order_relaxed);
+  }
+
   if (thread.low > max_low_)
   {
-    max_low_ = thread.low;
-    segments_ = thread.segments;
+    if (is_print_)
+    {
+      int64_t dist = thread.segment_size * thread.segments;
+      prev_thread_high = thread.low + dist;
+    }
 
     // We only start increasing the segment size and segments per
     // thread once the first special leaves have been found. Most
     // special leaves are located near the start (around y).
     // Hence, we assign tiny work chunks to the threads in this
     // region to avoid load imbalance.
-    if (!found_first_leaf_)
-      return;
+    if (found_first_leaf)
+      update_load_balancing(thread);
+  }
+  else
+  {
+    uint64_t segment_data = segment_data_.load(std::memory_order_relaxed);
+    thread.segment_size = segment_data & 0xffffffffu;
+    thread.segments = segment_data >> 32;
+  }
 
-    // If segment_size < L1_segment_size then slowly increase the
-    // segment size until it reaches L1_segment_size.
-    if (segment_size_ < L1_segment_size)
+  int64_t thread_dist = thread.segment_size * thread.segments;
+  thread.low = low_.fetch_add(thread_dist, std::memory_order_relaxed);
+  thread.sum = 0;
+  thread.secs = 0;
+  thread.init_secs = 0;
+
+  // Printing to the terminal incurs a system call
+  // and may hence be slow. Therefore, we do it
+  // after having released the mutex.
+  if (prev_thread_high)
+  {
+    double percent = status_.getStatus(prev_thread_high, sieve_limit_);
+    if (percent != 0)
     {
-      segment_size_ += segment_size_ / 16;
-      segment_size_ = min(segment_size_, L1_segment_size);
-      segment_size_ = Sieve::align_segment_size(segment_size_);
-      return;
-    }
-
-    // If segment_size >= L1_segment_size then slowly increase the
-    // segment size until it reaches L2_segment_size.
-    if (segment_size_ >= L1_segment_size &&
-        segment_size_ < L2_segment_size &&
-        segment_size_ < sqrt_limit_)
-    {
-      segment_size_ += segment_size_ / 16;
-      segment_size_ = min(segment_size_, L2_segment_size);
-      segment_size_ = Sieve::align_segment_size(segment_size_);
-      return;
-    }
-
-    update_number_of_segments(thread);
-
-    // The hard special leaves algorithm is basically a modified
-    // segmented sieve of Eratosthenes. Using the segmented sieve of
-    // Eratosthenes it is of utmost importance that sieve array fits
-    // into the CPU's cache, otherwise performance will deteriorate
-    // significantly and the algorithm will scale poorly.
-    //
-    // Deleglise-Rivat orignially suggested using a segment size of
-    // O(y). Xavier Gourdon realized this segment size was much too
-    // large for new record PrimePi(x) computations and hence
-    // suggested using a smaller segment size of O(sqrt(x/y)) which
-    // is the same as O(sqrt(sieve_limit)). However, for new record
-    // PrimePi(x) computations a segment size O(sqrt(sieve_limit))
-    // is still too large. Hence, I use an even smaller segment size
-    // of O(sqrt(high)) in primecount.
-    if (segment_size_ >= L2_segment_size &&
-        segment_size_ < sqrt_limit_)
-    {
-      int64_t dist = (segment_size_ * segments_) * threads_;
-      int64_t high = min(low_ + dist, sieve_limit_);
-
-      if (segment_size_ < isqrt(high))
+      TryLockGuard guard(print_lock_);
+      if (guard.owns_lock())
       {
-        segment_size_ += segment_size_ / 16;
-        dist = (segment_size_ * segments_) * threads_;
-        high = min(low_ + dist, sieve_limit_);
-        segment_size_ = isqrt(high);
-        segment_size_ = Sieve::align_segment_size(segment_size_);
+        double percent = status_.getStatus(prev_thread_high, sieve_limit_);
+        status_.print(percent);
       }
     }
   }
+
+  return thread.low < sieve_limit_;
+}
+
+void LoadBalancerS2::update_load_balancing(ThreadData& thread)
+{
+  max_low_ = thread.low;
+
+  int64_t segments = thread.segments;
+  int64_t segment_data = segment_data_.load(std::memory_order_relaxed);
+  int64_t segment_size = segment_data & 0xffffffffu;
+
+  // If segment_size < L1_segment_size then slowly increase the
+  // segment size until it reaches L1_segment_size.
+  if (segment_size < L1_segment_size)
+  {
+    segment_size += segment_size / 16;
+    segment_size = min(segment_size, L1_segment_size);
+    segment_size = Sieve::align_segment_size(segment_size);
+
+    store_packed(segment_size, segments);
+    thread.segment_size = segment_size;
+    thread.segments = segments;
+    return;
+  }
+
+  // If segment_size >= L1_segment_size then slowly increase the
+  // segment size until it reaches L2_segment_size.
+  if (segment_size >= L1_segment_size &&
+      segment_size < L2_segment_size &&
+      segment_size < sqrt_limit_)
+  {
+    segment_size += segment_size / 16;
+    segment_size = min(segment_size, L2_segment_size);
+    segment_size = Sieve::align_segment_size(segment_size);
+
+    store_packed(segment_size, segments);
+    thread.segment_size = segment_size;
+    thread.segments = segments;
+    return;
+  }
+
+  int64_t low = low_.load(std::memory_order_relaxed);
+  segments = update_number_of_segments(segments, low, thread);
+
+  // The hard special leaves algorithm is basically a modified
+  // segmented sieve of Eratosthenes. Using the segmented sieve of
+  // Eratosthenes it is of utmost importance that sieve array fits
+  // into the CPU's cache, otherwise performance will deteriorate
+  // significantly and the algorithm will scale poorly.
+  //
+  // Deleglise-Rivat orignially suggested using a segment size of
+  // O(y). Xavier Gourdon realized this segment size was much too
+  // large for new record PrimePi(x) computations and hence
+  // suggested using a smaller segment size of O(sqrt(x/y)) which
+  // is the same as O(sqrt(sieve_limit)). However, for new record
+  // PrimePi(x) computations a segment size O(sqrt(sieve_limit))
+  // is still too large. Hence, I use an even smaller segment size
+  // of O(sqrt(high)) in primecount.
+  if (segment_size >= L2_segment_size &&
+      segment_size < sqrt_limit_)
+  {
+    int64_t dist = (segment_size * segments) * threads_;
+    int64_t high = min(low + dist, sieve_limit_);
+
+    if (segment_size < isqrt(high))
+    {
+      segment_size += segment_size / 16;
+      dist = (segment_size * segments) * threads_;
+      high = min(low + dist, sieve_limit_);
+      segment_size = isqrt(high);
+      segment_size = Sieve::align_segment_size(segment_size);
+    }
+  }
+
+  store_packed(segment_size, segments);
+  thread.segment_size = segment_size;
+  thread.segments = segments;
 }
 
 /// Increase or decrease the number of segments per
 /// thread based on the remaining runtime.
 ///
-void LoadBalancerS2::update_number_of_segments(const ThreadData& thread)
+int64_t LoadBalancerS2::update_number_of_segments(int64_t segments,
+                                                  int64_t low,
+                                                  const ThreadData& thread) const
 {
   // Near the end it is important that threads run only for
   // a short amount of time in order to ensure that all
   // threads finish nearly at the same time. Since the
   // remaining time is just a rough estimation we want to be
   // very conservative so we divide the remaining time by 3.
-  double rem_secs = remaining_secs() / 3;
+  double rem_secs = remaining_secs(low) / 3;
 
   // If the previous thread runtime is larger than the
   // estimated remaining time the factor that we calculate
@@ -283,23 +332,15 @@ void LoadBalancerS2::update_number_of_segments(const ThreadData& thread)
   double next_runtime = thread.secs * factor;
 
   if (next_runtime < min_secs)
-    segments_ *= 2;
+    segments *= 2;
   else
   {
-    double new_segments = std::round(segments_ * factor);
-    segments_ = (int64_t) new_segments;
-    segments_ = max(segments_, 1);
+    double new_segments = std::round(segments * factor);
+    segments = (int64_t) new_segments;
+    segments = max(segments, 1);
   }
-}
 
-/// Remaining seconds till finished
-double LoadBalancerS2::remaining_secs() const
-{
-  double percent = status_.getPercent(low_, sieve_limit_);
-  percent = in_between(10, percent, 100);
-  double total_secs = get_time() - time_;
-  double secs = total_secs * (100 / percent) - total_secs;
-  return secs;
+  return segments;
 }
 
 } // namespace

--- a/src/LoadBalancerS2.cpp
+++ b/src/LoadBalancerS2.cpp
@@ -133,6 +133,12 @@ double LoadBalancerS2::remaining_secs(int64_t low) const
   return secs;
 }
 
+/// Assign new [low, high[ workload to thread.
+/// Multiple threads may call get_work() simultaneously, since
+/// this function is not protected by a mutex, it must not
+/// modify any shared member variables, except the atomic low_
+/// max_low_, segment_data_, found_first_leaf_ variables.
+///
 bool LoadBalancerS2::get_work(ThreadData& thread)
 {
   int64_t max_low = max_low_.load(std::memory_order_relaxed);
@@ -150,11 +156,10 @@ bool LoadBalancerS2::get_work(ThreadData& thread)
 
   if (thread.low <= max_low)
   {
-    // Use old values, don't run load balancing
     thread.segment_size = segment_size;
     thread.segments = segments;
   }
-  else
+  else // thread.low > max_low
   {
     max_low_.store(thread.low, std::memory_order_relaxed);
 
@@ -164,11 +169,11 @@ bool LoadBalancerS2::get_work(ThreadData& thread)
       print_high = thread.low + dist;
     }
 
-    // We only start increasing the segment size and segments per
-    // thread once the first special leaves have been found. Most
-    // special leaves are located near the start (around y).
-    // Hence, we assign tiny work chunks to the threads in this
-    // region to avoid load imbalance.
+    // We only start increasing the segment size and segments
+    // per thread once the first special leaf has been found.
+    // Most special leaves are located near the start (near y).
+    // Hence, we assign tiny work chunks to the threads in
+    // this region to avoid load imbalance.
     if (found_first_leaf)
       run_load_balancing(thread, segment_size);
     else
@@ -178,15 +183,18 @@ bool LoadBalancerS2::get_work(ThreadData& thread)
     }
   }
 
+  // The earlier loads are used for heuristic chunk
+  // sizing, it is OK if they are slightly outdated. This
+  // fetch_add() reserves unique work for this thread.
   int64_t dist = thread.segment_size * thread.segments;
   thread.low = low_.fetch_add(dist, std::memory_order_relaxed);
   thread.sum = 0;
   thread.secs = 0;
   thread.init_secs = 0;
 
-  // Printing to the terminal incurs a system call
-  // and may hence be slow. Therefore, we do it
-  // after the lockfree work assignment.
+  // The lockfree critical section above should complete
+  // as fast as possible. Hence, printing should be done
+  // afterwards since it may incur a system call.
   if (print_high)
     print_S2_status(print_high);
 
@@ -198,8 +206,8 @@ void LoadBalancerS2::run_load_balancing(ThreadData& thread,
 {
   int64_t segments = thread.segments;
 
-  // If segment_size < L1_segment_size then slowly increase the
-  // segment size until it reaches L1_segment_size.
+  // If segment_size < L1_segment_size then slowly increase
+  // the segment size until it reaches L1_segment_size.
   if (segment_size < L1_segment_size)
   {
     segment_size += segment_size / 16;
@@ -213,8 +221,8 @@ void LoadBalancerS2::run_load_balancing(ThreadData& thread,
     return;
   }
 
-  // If segment_size >= L1_segment_size then slowly increase the
-  // segment size until it reaches L2_segment_size.
+  // If segment_size >= L1_segment_size then slowly increase
+  // the segment size until it reaches L2_segment_size.
   if (segment_size >= L1_segment_size &&
       segment_size < L2_segment_size &&
       segment_size < sqrt_limit_)

--- a/src/LoadBalancerS2.cpp
+++ b/src/LoadBalancerS2.cpp
@@ -111,6 +111,16 @@ LoadBalancerS2::LoadBalancerS2(maxint_t x,
   store_packed(segment_size, segments);
 }
 
+/// Remaining seconds till finished
+double LoadBalancerS2::remaining_secs(int64_t low) const
+{
+  double percent = status_.getPercent(low, sieve_limit_);
+  percent = in_between(10, percent, 100);
+  double total_secs = get_time() - start_time_;
+  double secs = total_secs * (100 / percent) - total_secs;
+  return secs;
+}
+
 /// Pack segment_size & segments into a uint64_t,
 /// needed for lockfree atomic data access.
 ///
@@ -121,16 +131,6 @@ void LoadBalancerS2::store_packed(int64_t segment_size,
   ASSERT(segment_size <= max_packed_segment_size);
   uint64_t packed = uint64_t(segment_size) | (uint64_t(segments) << 32);
   segment_data_.store(packed, std::memory_order_relaxed);
-}
-
-/// Remaining seconds till finished
-double LoadBalancerS2::remaining_secs(int64_t low) const
-{
-  double percent = status_.getPercent(low, sieve_limit_);
-  percent = in_between(10, percent, 100);
-  double total_secs = get_time() - start_time_;
-  double secs = total_secs * (100 / percent) - total_secs;
-  return secs;
 }
 
 /// Assign new [low, high[ workload to thread.

--- a/src/LoadBalancerS2.cpp
+++ b/src/LoadBalancerS2.cpp
@@ -188,7 +188,7 @@ bool LoadBalancerS2::get_work(ThreadData& thread)
     thread.segments = segments;
   }
 
-  // The earlier loads are used for heuristic chunk
+  // The earlier loads are only used for heuristic chunk
   // sizing, it is OK if they are slightly outdated. This
   // fetch_add() reserves unique work for this thread.
   int64_t dist = thread.segment_size * thread.segments;

--- a/src/LoadBalancerS2.cpp
+++ b/src/LoadBalancerS2.cpp
@@ -148,13 +148,6 @@ bool LoadBalancerS2::get_work(ThreadData& thread)
   int64_t segment_size = segment_data & 0xffffffffu;
   int64_t segments = segment_data >> 32;
 
-  if (is_print_ &&
-      thread.low >= max_low)
-  {
-    int64_t dist = thread.segment_size * thread.segments;
-    print_high = thread.low + dist;
-  }
-
   if (thread.sum &&
       !found_first_leaf)
   {
@@ -162,21 +155,30 @@ bool LoadBalancerS2::get_work(ThreadData& thread)
     found_first_leaf = true;
   }
 
-  // We only start increasing the segment size and segments
-  // per thread once the first special leaf has been found.
-  // Most special leaves are located near the start (near y).
-  // Hence, we assign tiny work chunks to the threads in
-  // this region to avoid load imbalance.
-  if (thread.low <= max_low ||
-      !found_first_leaf)
+  if (thread.low <= max_low)
   {
     thread.segment_size = segment_size;
     thread.segments = segments;
   }
-  else
+  else // thread.low > max_low
   {
     max_low_.store(thread.low, std::memory_order_relaxed);
-    run_load_balancing(thread, segment_size);
+
+    if (is_print_)
+      print_high = thread.low + thread.segment_size * thread.segments;
+
+    // We only start increasing the segment size and segments
+    // per thread once the first special leaf has been found.
+    // Most special leaves are located near the start (near y).
+    // Hence, we assign tiny work chunks to the threads in
+    // this region to avoid load imbalance.
+    if (found_first_leaf)
+      run_load_balancing(thread, segment_size);
+    else
+    {
+      thread.segment_size = segment_size;
+      thread.segments = segments;
+    }
   }
 
   // The earlier loads are used for heuristic chunk

--- a/src/LoadBalancerS2.cpp
+++ b/src/LoadBalancerS2.cpp
@@ -54,11 +54,9 @@ namespace {
 // size but smaller than the L2 cache size (per core).
 
 constexpr int64_t numbers_per_byte = 30;
-constexpr int64_t segment_size_alignment = 240;
 constexpr int64_t L1_segment_size = L1_CACHE_SIZE * numbers_per_byte;
 constexpr int64_t L2_segment_size = L2_CACHE_SIZE * numbers_per_byte;
-constexpr int64_t max_packed_segment_size =
-    UINT32_MAX - (UINT32_MAX % segment_size_alignment);
+constexpr int64_t max_segment_size = UINT32_MAX - 240;
 
 } // namespace
 
@@ -84,7 +82,7 @@ LoadBalancerS2::LoadBalancerS2(maxint_t x,
   {
     segment_size = L1_segment_size;
     segment_size = min(segment_size, sieve_limit);
-    segment_size = min(segment_size, max_packed_segment_size);
+    segment_size = min(segment_size, max_segment_size);
     segment_size = Sieve::align_segment_size(segment_size);
 
     // Currently our Sieve.cpp does not rebalance its
@@ -103,7 +101,7 @@ LoadBalancerS2::LoadBalancerS2(maxint_t x,
     // assigned an equal amount of work.
     segment_size = isqrt(isqrt(x));
     segment_size = max(segment_size, 1 << 9);
-    segment_size = min(segment_size, max_packed_segment_size);
+    segment_size = min(segment_size, max_segment_size);
     segment_size = Sieve::align_segment_size(segment_size);
     segments = 1;
   }
@@ -217,7 +215,7 @@ void LoadBalancerS2::run_load_balancing(ThreadData& thread,
   {
     segment_size += segment_size / 16;
     segment_size = min(segment_size, L1_segment_size);
-    segment_size = min(segment_size, max_packed_segment_size);
+    segment_size = min(segment_size, max_segment_size);
     segment_size = Sieve::align_segment_size(segment_size);
 
     store_packed(segment_size, thread.segments);
@@ -233,7 +231,7 @@ void LoadBalancerS2::run_load_balancing(ThreadData& thread,
   {
     segment_size += segment_size / 16;
     segment_size = min(segment_size, L2_segment_size);
-    segment_size = min(segment_size, max_packed_segment_size);
+    segment_size = min(segment_size, max_segment_size);
     segment_size = Sieve::align_segment_size(segment_size);
 
     store_packed(segment_size, thread.segments);

--- a/src/LoadBalancerS2.cpp
+++ b/src/LoadBalancerS2.cpp
@@ -124,12 +124,12 @@ double LoadBalancerS2::remaining_secs(int64_t low) const
 /// Pack segment_size & segments into a uint64_t,
 /// needed for lockfree atomic data access.
 ///
-void LoadBalancerS2::store_packed(int64_t segment_size,
-                                  int64_t segments)
+void LoadBalancerS2::store_packed(uint64_t segment_size,
+                                  uint64_t segments)
 {
-  ASSERT(segments <= max_packed_segment_size);
-  ASSERT(segment_size <= max_packed_segment_size);
-  uint64_t packed = uint64_t(segment_size) | (uint64_t(segments) << 32);
+  ASSERT(segments <= UINT32_MAX);
+  ASSERT(segment_size <= UINT32_MAX);
+  uint64_t packed = segment_size | (segments << 32);
   segment_data_.store(packed, std::memory_order_relaxed);
 }
 

--- a/src/LoadBalancerS2.cpp
+++ b/src/LoadBalancerS2.cpp
@@ -58,7 +58,7 @@ constexpr int64_t segment_size_alignment = 240;
 constexpr int64_t L1_segment_size = L1_CACHE_SIZE * numbers_per_byte;
 constexpr int64_t L2_segment_size = L2_CACHE_SIZE * numbers_per_byte;
 constexpr int64_t max_packed_segment_size =
-    INT32_MAX - (INT32_MAX % segment_size_alignment);
+    UINT32_MAX - (UINT32_MAX % segment_size_alignment);
 
 } // namespace
 
@@ -101,10 +101,9 @@ LoadBalancerS2::LoadBalancerS2(maxint_t x,
     // special leaves are located in the first few segments
     // and as we need to ensure that all threads are
     // assigned an equal amount of work.
-    maxint_t x14 = isqrt(isqrt(x));
-    segment_size = (x14 > max_packed_segment_size) ?
-        max_packed_segment_size : (int64_t) x14;
-    segment_size = max(segment_size, (int64_t) 1 << 9);
+    segment_size = isqrt(isqrt(x));
+    segment_size = max(segment_size, 1 << 9);
+    segment_size = min(segment_size, max_packed_segment_size);
     segment_size = Sieve::align_segment_size(segment_size);
     segments = 1;
   }
@@ -118,25 +117,10 @@ LoadBalancerS2::LoadBalancerS2(maxint_t x,
 void LoadBalancerS2::store_packed(int64_t segment_size,
                                   int64_t segments)
 {
-  ASSERT(segments <= INT32_MAX);
-  ASSERT(segment_size <= INT32_MAX);
-  uint64_t packed = (uint64_t) segment_size | ((uint64_t) segments << 32);
+  ASSERT(segments <= max_packed_segment_size);
+  ASSERT(segment_size <= max_packed_segment_size);
+  uint64_t packed = uint64_t(segment_size) | (uint64_t(segments) << 32);
   segment_data_.store(packed, std::memory_order_relaxed);
-}
-
-bool LoadBalancerS2::update_max_low(int64_t low)
-{
-  int64_t max_low = max_low_.load(std::memory_order_relaxed);
-
-  while (low > max_low)
-  {
-    if (max_low_.compare_exchange_weak(max_low, low,
-                                       std::memory_order_relaxed,
-                                       std::memory_order_relaxed))
-      return true;
-  }
-
-  return false;
 }
 
 /// Remaining seconds till finished
@@ -151,22 +135,33 @@ double LoadBalancerS2::remaining_secs(int64_t low) const
 
 bool LoadBalancerS2::get_work(ThreadData& thread)
 {
-  int64_t prev_thread_high = 0;
+  int64_t max_low = max_low_.load(std::memory_order_relaxed);
   bool found_first_leaf = found_first_leaf_.load(std::memory_order_relaxed);
-  bool updated_segment_data = false;
+  uint64_t segment_data = segment_data_.load(std::memory_order_relaxed);
+  int64_t segment_size = segment_data & 0xffffffffu;
+  int64_t segments = segment_data >> 32;
+  int64_t print_high = 0;
 
   if (thread.sum && !found_first_leaf)
   {
-    found_first_leaf = true;
     found_first_leaf_.store(true, std::memory_order_relaxed);
+    found_first_leaf = true;
   }
 
-  if (update_max_low(thread.low))
+  if (thread.low <= max_low)
   {
+    // Use old values, don't run load balancing
+    thread.segment_size = segment_size;
+    thread.segments = segments;
+  }
+  else
+  {
+    max_low_.store(thread.low, std::memory_order_relaxed);
+
     if (is_print_)
     {
       int64_t dist = thread.segment_size * thread.segments;
-      prev_thread_high = thread.low + dist;
+      print_high = thread.low + dist;
     }
 
     // We only start increasing the segment size and segments per
@@ -175,30 +170,16 @@ bool LoadBalancerS2::get_work(ThreadData& thread)
     // Hence, we assign tiny work chunks to the threads in this
     // region to avoid load imbalance.
     if (found_first_leaf)
+      run_load_balancing(thread, segment_size);
+    else
     {
-      update_load_balancing(thread);
-      updated_segment_data = true;
+      thread.segment_size = segment_size;
+      thread.segments = segments;
     }
   }
 
-  if (!updated_segment_data)
-  {
-    uint64_t segment_data = segment_data_.load(std::memory_order_relaxed);
-    thread.segment_size = segment_data & 0xffffffffu;
-    thread.segments = segment_data >> 32;
-  }
-
-  int64_t low = low_.load(std::memory_order_relaxed);
-  if (low >= sieve_limit_)
-  {
-    if (prev_thread_high)
-      print_S2_status(prev_thread_high);
-
-    return false;
-  }
-
-  int64_t thread_dist = thread.segment_size * thread.segments;
-  thread.low = low_.fetch_add(thread_dist, std::memory_order_relaxed);
+  int64_t dist = thread.segment_size * thread.segments;
+  thread.low = low_.fetch_add(dist, std::memory_order_relaxed);
   thread.sum = 0;
   thread.secs = 0;
   thread.init_secs = 0;
@@ -206,17 +187,16 @@ bool LoadBalancerS2::get_work(ThreadData& thread)
   // Printing to the terminal incurs a system call
   // and may hence be slow. Therefore, we do it
   // after the lockfree work assignment.
-  if (prev_thread_high)
-    print_S2_status(prev_thread_high);
+  if (print_high)
+    print_S2_status(print_high);
 
   return thread.low < sieve_limit_;
 }
 
-void LoadBalancerS2::update_load_balancing(ThreadData& thread)
+void LoadBalancerS2::run_load_balancing(ThreadData& thread,
+                                        int64_t segment_size)
 {
   int64_t segments = thread.segments;
-  int64_t segment_data = segment_data_.load(std::memory_order_relaxed);
-  int64_t segment_size = segment_data & 0xffffffffu;
 
   // If segment_size < L1_segment_size then slowly increase the
   // segment size until it reaches L1_segment_size.
@@ -279,7 +259,6 @@ void LoadBalancerS2::update_load_balancing(ThreadData& thread)
       dist = (segment_size * segments) * threads_;
       high = min(low + dist, sieve_limit_);
       segment_size = isqrt(high);
-      segment_size = min(segment_size, max_packed_segment_size);
       segment_size = Sieve::align_segment_size(segment_size);
     }
   }
@@ -370,11 +349,11 @@ int64_t LoadBalancerS2::update_number_of_segments(int64_t segments,
     segments = max(segments, 1);
   }
 
-  segments = min(segments, (int64_t) INT32_MAX);
+  segments = min(segments, UINT32_MAX);
   return segments;
 }
 
-void LoadBalancerS2::print_S2_status(int64_t low)
+void LoadBalancerS2::print_S2_status(int64_t high)
 {
   double time = get_time();
 
@@ -407,10 +386,7 @@ void LoadBalancerS2::print_S2_status(int64_t low)
 
     // The next thread can print again in 0.1 seconds.
     next_print_time_.store(time + 0.1, std::memory_order_relaxed);
-
-    double percent = status_.getStatus(low, sieve_limit_);
-    if (percent >= 0)
-      status_.print(percent);
+    status_.print_S2_hard(high, sieve_limit_);
   }
 }
 

--- a/src/LoadBalancerS2.cpp
+++ b/src/LoadBalancerS2.cpp
@@ -141,46 +141,42 @@ void LoadBalancerS2::store_packed(int64_t segment_size,
 ///
 bool LoadBalancerS2::get_work(ThreadData& thread)
 {
+  int64_t print_high = 0;
   int64_t max_low = max_low_.load(std::memory_order_relaxed);
   bool found_first_leaf = found_first_leaf_.load(std::memory_order_relaxed);
   uint64_t segment_data = segment_data_.load(std::memory_order_relaxed);
   int64_t segment_size = segment_data & 0xffffffffu;
   int64_t segments = segment_data >> 32;
-  int64_t print_high = 0;
 
-  if (thread.sum && !found_first_leaf)
+  if (is_print_ &&
+      thread.low >= max_low)
+  {
+    int64_t dist = thread.segment_size * thread.segments;
+    print_high = thread.low + dist;
+  }
+
+  if (thread.sum &&
+      !found_first_leaf)
   {
     found_first_leaf_.store(true, std::memory_order_relaxed);
     found_first_leaf = true;
   }
 
-  if (thread.low <= max_low)
+  // We only start increasing the segment size and segments
+  // per thread once the first special leaf has been found.
+  // Most special leaves are located near the start (near y).
+  // Hence, we assign tiny work chunks to the threads in
+  // this region to avoid load imbalance.
+  if (thread.low <= max_low ||
+      !found_first_leaf)
   {
     thread.segment_size = segment_size;
     thread.segments = segments;
   }
-  else // thread.low > max_low
+  else
   {
     max_low_.store(thread.low, std::memory_order_relaxed);
-
-    if (is_print_)
-    {
-      int64_t dist = thread.segment_size * thread.segments;
-      print_high = thread.low + dist;
-    }
-
-    // We only start increasing the segment size and segments
-    // per thread once the first special leaf has been found.
-    // Most special leaves are located near the start (near y).
-    // Hence, we assign tiny work chunks to the threads in
-    // this region to avoid load imbalance.
-    if (found_first_leaf)
-      run_load_balancing(thread, segment_size);
-    else
-    {
-      thread.segment_size = segment_size;
-      thread.segments = segments;
-    }
+    run_load_balancing(thread, segment_size);
   }
 
   // The earlier loads are used for heuristic chunk

--- a/src/LoadBalancerS2.hpp
+++ b/src/LoadBalancerS2.hpp
@@ -11,12 +11,13 @@
 #define LOADBALANCERS2_HPP
 
 #include <primecount-internal.hpp>
+#include <primecount-config.hpp>
 #include <int128_t.hpp>
 #include <macros.hpp>
-#include <OmpLock.hpp>
 #include <StatusS2.hpp>
 
 #include <stdint.h>
+#include <atomic>
 
 namespace primecount {
 
@@ -58,22 +59,28 @@ public:
   bool get_work(ThreadData& thread);
 
 private:
-  void update_load_balancing(const ThreadData& thread);
-  void update_number_of_segments(const ThreadData& thread);
-  double remaining_secs() const;
+  void store_packed(int64_t segment_size, int64_t segments);
+  void update_load_balancing(ThreadData& thread);
+  int64_t update_number_of_segments(int64_t segments, int64_t low, const ThreadData& thread) const;
+  double remaining_secs(int64_t low) const;
 
-  int64_t low_ = 0;
   int64_t max_low_ = 0;
   int64_t sieve_limit_ = 0;
   int64_t sqrt_limit_ = 0;
-  int64_t segments_ = 0;
-  int64_t segment_size_ = 0;
-  double time_ = 0;
+  double start_time_ = 0;
   int threads_ = 0;
-  bool found_first_leaf_ = false;
   bool is_print_ = false;
   StatusS2 status_;
-  OmpLock lock_;
+
+  MAYBE_UNUSED char pad1[MAX_CACHE_LINE_SIZE];
+  std::atomic<int64_t> low_{0};
+  MAYBE_UNUSED char pad2[MAX_CACHE_LINE_SIZE];
+  std::atomic<uint64_t> segment_data_{0};
+  MAYBE_UNUSED char pad3[MAX_CACHE_LINE_SIZE];
+  std::atomic<double> next_print_time_{0};
+  std::atomic<bool> print_lock_{false};
+  std::atomic<bool> found_first_leaf_{false};
+  MAYBE_UNUSED char pad4[MAX_CACHE_LINE_SIZE];
 };
 
 } // namespace

--- a/src/LoadBalancerS2.hpp
+++ b/src/LoadBalancerS2.hpp
@@ -60,7 +60,7 @@ public:
 
 private:
   double remaining_secs(int64_t low) const;
-  void store_packed(int64_t segment_size, int64_t segments);
+  void store_packed(uint64_t segment_size, uint64_t segments);
   void run_load_balancing(ThreadData& thread, int64_t segment_size);
   int64_t update_number_of_segments(int64_t segments, int64_t low, const ThreadData& thread) const;
   void print_S2_status(int64_t high);

--- a/src/LoadBalancerS2.hpp
+++ b/src/LoadBalancerS2.hpp
@@ -62,7 +62,7 @@ private:
   double remaining_secs(int64_t low) const;
   void store_packed(uint64_t segment_size, uint64_t segments);
   void run_load_balancing(ThreadData& thread, int64_t segment_size);
-  int64_t update_number_of_segments(int64_t segments, int64_t low, const ThreadData& thread) const;
+  int64_t get_segments(const ThreadData& thread, int64_t low) const;
   void print_S2_status(int64_t high);
 
   int64_t sieve_limit_ = 0;

--- a/src/LoadBalancerS2.hpp
+++ b/src/LoadBalancerS2.hpp
@@ -59,12 +59,11 @@ public:
   bool get_work(ThreadData& thread);
 
 private:
-  void store_packed(int64_t segment_size, int64_t segments);
-  bool update_max_low(int64_t low);
-  void update_load_balancing(ThreadData& thread);
-  int64_t update_number_of_segments(int64_t segments, int64_t low, const ThreadData& thread) const;
-  void print_S2_status(int64_t low);
   double remaining_secs(int64_t low) const;
+  void store_packed(int64_t segment_size, int64_t segments);
+  void run_load_balancing(ThreadData& thread, int64_t segment_size);
+  int64_t update_number_of_segments(int64_t segments, int64_t low, const ThreadData& thread) const;
+  void print_S2_status(int64_t high);
 
   int64_t sieve_limit_ = 0;
   int64_t sqrt_limit_ = 0;

--- a/src/LoadBalancerS2.hpp
+++ b/src/LoadBalancerS2.hpp
@@ -60,11 +60,12 @@ public:
 
 private:
   void store_packed(int64_t segment_size, int64_t segments);
+  bool update_max_low(int64_t low);
   void update_load_balancing(ThreadData& thread);
   int64_t update_number_of_segments(int64_t segments, int64_t low, const ThreadData& thread) const;
+  void print_S2_status(int64_t low);
   double remaining_secs(int64_t low) const;
 
-  int64_t max_low_ = 0;
   int64_t sieve_limit_ = 0;
   int64_t sqrt_limit_ = 0;
   double start_time_ = 0;
@@ -75,12 +76,14 @@ private:
   MAYBE_UNUSED char pad1[MAX_CACHE_LINE_SIZE];
   std::atomic<int64_t> low_{0};
   MAYBE_UNUSED char pad2[MAX_CACHE_LINE_SIZE];
-  std::atomic<uint64_t> segment_data_{0};
+  std::atomic<int64_t> max_low_{0};
   MAYBE_UNUSED char pad3[MAX_CACHE_LINE_SIZE];
+  std::atomic<uint64_t> segment_data_{0};
+  MAYBE_UNUSED char pad4[MAX_CACHE_LINE_SIZE];
   std::atomic<double> next_print_time_{0};
   std::atomic<bool> print_lock_{false};
   std::atomic<bool> found_first_leaf_{false};
-  MAYBE_UNUSED char pad4[MAX_CACHE_LINE_SIZE];
+  MAYBE_UNUSED char pad5[MAX_CACHE_LINE_SIZE];
 };
 
 } // namespace

--- a/src/StatusS2.cpp
+++ b/src/StatusS2.cpp
@@ -122,32 +122,19 @@ double StatusS2::getPercent(int64_t low, int64_t limit) const
 /// LoadBalancerS2.cpp and hence it can never be accessed
 /// simultaneously from multiple threads.
 ///
-double StatusS2::getStatus(int64_t low, int64_t limit)
+void StatusS2::print_S2_hard(int64_t low, int64_t limit)
 {
-  double time = get_time();
-  double old = time_;
+  double old = percent_;
+  double percent = getPercent(low, limit);
 
-  if ((time - old) >= threshold_)
+  if ((percent - old) >= epsilon_)
   {
-    time_ = time;
-    double old = percent_;
-    double percent = getPercent(low, limit);
-    if ((percent - old) >= epsilon_)
-    {
-      percent_ = percent;
-      return percent;
-    }
+    percent_ = percent;
+    std::string status = "Status: ";
+    status += to_string(percent, precision_);
+    status += '%';
+    print_status(status);
   }
-
-  return -1;
-}
-
-void StatusS2::print(double percent) const
-{
-  std::string status = "Status: ";
-  status += to_string(percent, precision_);
-  status += '%';
-  print_status(status);
 }
 
 /// This method is used by S2_easy().
@@ -156,7 +143,7 @@ void StatusS2::print(double percent) const
 /// S2_easy.cpp and hence it can never be accessed
 /// simultaneously from multiple threads.
 ///
-void StatusS2::print(int64_t b, int64_t max_b)
+void StatusS2::print_S2_easy(int64_t b, int64_t max_b)
 {
   double time = get_time();
   double old = time_;
@@ -179,7 +166,10 @@ void StatusS2::print(int64_t b, int64_t max_b)
     if ((percent - percent_) >= epsilon_)
     {
       percent_ = percent;
-      print(percent);
+      std::string status = "Status: ";
+      status += to_string(percent, precision_);
+      status += '%';
+      print_status(status);
     }
   }
 }

--- a/src/StatusS2.hpp
+++ b/src/StatusS2.hpp
@@ -18,10 +18,9 @@ class StatusS2
 {
 public:
   StatusS2(maxint_t x, int64_t y, bool is_print);
-  void print(double percent) const;
-  void print(int64_t b, int64_t max_b);
   double getPercent(int64_t low, int64_t limit) const;
-  double getStatus(int64_t low, int64_t limit);
+  void print_S2_hard(int64_t b, int64_t max_b);
+  void print_S2_easy(int64_t b, int64_t max_b);
 
 private:
   int64_t y_log_y_ = 0;

--- a/src/deleglise-rivat/S2_easy.cpp
+++ b/src/deleglise-rivat/S2_easy.cpp
@@ -150,7 +150,7 @@ T S2_easy_OpenMP(T x,
       #pragma omp master
     #endif
     if (is_print)
-      status.print(b, pi_x13);
+      status.print_S2_easy(b, pi_x13);
   }
 
   return sum;
@@ -384,7 +384,7 @@ T S2_easy_OpenMP(T x,
       #pragma omp master
     #endif
     if (is_print)
-      status.print(b, pi_x13);
+      status.print_S2_easy(b, pi_x13);
   }
 
   return sum;

--- a/test/nth_prime_sieve.cpp
+++ b/test/nth_prime_sieve.cpp
@@ -10,8 +10,10 @@
 ///
 
 #include <nth_prime_sieve.hpp>
+#include <primecount.hpp>
 
 #include <stdint.h>
+#include <algorithm>
 #include <cstdlib>
 #include <iostream>
 
@@ -1045,9 +1047,10 @@ const TestCase test_cases[] =
 void check_nth_prime_sieve(int64_t n,
                            int64_t nth_prime_approx,
                            int64_t count_approx,
-                           int64_t nth_prime)
+                           int64_t nth_prime,
+                           int threads)
 {
-  int64_t res = nth_prime_sieve(n, nth_prime_approx, count_approx, 4);
+  int64_t res = nth_prime_sieve(n, nth_prime_approx, count_approx, threads);
   std::cout << "nth_prime_sieve(" << n << ", "
             << nth_prime_approx << ", "
             << count_approx << ") = " << res;
@@ -1056,11 +1059,15 @@ void check_nth_prime_sieve(int64_t n,
 
 int main()
 {
+  int threads = get_num_threads();
+  threads = std::min(threads, 4);
+
   for (const TestCase& test : test_cases)
     check_nth_prime_sieve(test.n,
                           test.nth_prime_approx,
                           test.count_approx,
-                          test.nth_prime);
+                          test.nth_prime,
+                          threads);
 
   std::cout << std::endl;
   std::cout << "All tests passed successfully!" << std::endl;
@@ -1117,7 +1124,9 @@ int64_t nth_prime_from_iterator(int64_t n,
 
 int main()
 {
-  constexpr int threads = 4;
+  int threads = get_num_threads();
+  threads = std::min(threads, 4);
+
   std::vector<TestCase> cases;
   std::set<int64_t> seen_n;
 


### PR DESCRIPTION
Get rid of the mutex in `LoadBalancerS2::get_work()`, this improves the performance of short computations on many-core PCs/servers. This change significantly improves performance when primecount is compiled using LLVM/Clang.