### PR TITLE
New sieving algorithm for small sieving primes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,8 +1,8 @@
 Changes in primecount-8.6, 2026-07-13
 
 * Update to libprimesieve 12.15.
-* Sieve.cpp: New sieving algorithm for small primes. Up to 40% faster
-  on Apple M2 CPU and up to 10% faster on AMD Zen5 CPU.
+* Sieve.cpp: New sieving algorithm for small primes #122.
+  Up to 45% faster on Apple M2 CPU and up to 10% faster on AMD Zen5 CPU.
 * macros.hpp: Add INDETERMINATE macro to prevent memset zero initialization of large stack arrays.
 * Sieve_count_simd.hpp: Fix undefined behavior.
 * Sieve.hpp: Use Vector<uint64_t> sieve to fix undefined behavior.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,8 @@
-Changes in primecount-8.6, 2026-07-08
+Changes in primecount-8.6, 2026-07-13
 
 * Update to libprimesieve 12.15.
+* Sieve.cpp: New sieving algorithm for small primes. Up to 40% faster
+  on Apple M2 CPU and up to 10% faster on AMD Zen5 CPU.
 * macros.hpp: Add INDETERMINATE macro to prevent memset zero initialization of large stack arrays.
 * Sieve_count_simd.hpp: Fix undefined behavior.
 * Sieve.hpp: Use Vector<uint64_t> sieve to fix undefined behavior.

--- a/src/Sieve.cpp
+++ b/src/Sieve.cpp
@@ -168,8 +168,6 @@ void Sieve::init_counter(uint64_t low, uint64_t high)
 {
   reset_counter();
   total_count_ = 0;
-  many_hits_threshold_ = counter_.counter.size() * 2;
-  many_hits_per_bucket_ = true;
 
   uint64_t start = 0;
   uint64_t max_stop = (high - 1) - low;
@@ -518,6 +516,11 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
     return;
   }
 
+  uint64_t count = 0;
+  uint32_t* counter = &counter_[0];
+  uint64_t counter_log2_dist = counter_.log2_dist;
+  bool is_small_prime = (prime <= (4ull << counter_log2_dist));
+
   prime /= 30;
   uint64_t adv0 = prime * 6 + wheel_corr[g][0];
   uint64_t adv1 = prime * 4 + wheel_corr[g][1];
@@ -528,10 +531,6 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
   uint64_t adv6 = prime * 6 + wheel_corr[g][6];
   uint64_t adv7 = prime * 2 + wheel_corr[g][7];
 
-  uint64_t count = 0;
-  uint64_t counter_log2_dist = counter_.log2_dist;
-  uint32_t* counter = &counter_[0];
-
   // A small sieving prime hits the same counter array bucket
   // many times in a row. Decrementing counter[bucket] on each
   // hit is a read-modify-write to the same address, so on
@@ -540,7 +539,7 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
   // alternative algorithm that avoids this by accumulating a
   // bucket's hits in a register, writing counter[bucket] back
   // only once per bucket.
-  if (many_hits_per_bucket_)
+  if (is_small_prime)
   {
     uint64_t cur_bucket = m >> counter_log2_dist;
     uint64_t bucket_count = 0;
@@ -747,7 +746,6 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
     counter[cur_bucket] -= uint32_t(bucket_count);
     count += bucket_count;
     total_count_ -= count;
-    many_hits_per_bucket_ = (count >= many_hits_threshold_);
   }
   else
   {

--- a/src/Sieve.cpp
+++ b/src/Sieve.cpp
@@ -540,7 +540,7 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
   // only once per bucket.
   if (is_small_prime)
   {
-    uint64_t cur_bucket = m >> counter_log2_dist;
+    uint64_t bucket_threshold = ((m >> counter_log2_dist) + 1) << counter_log2_dist;
     uint64_t bucket_count = 0;
 
     #define CHECK_FINISHED(w) \
@@ -550,15 +550,22 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
         goto finished1; \
       }
 
+    // bucket_threshold is the byte offset where the current bucket
+    // ends. Comparing m against it avoids recomputing the bucket index
+    // (m >> counter_log2_dist) on every hit. We deliberately carry only
+    // this single loop variable and recompute cur_bucket from it in the
+    // rarely taken branch below: carrying both cur_bucket and
+    // bucket_threshold adds an extra live value that makes GCC 16 spill
+    // in the inner loop (worst with -march=znver5), which is up to 10%
+    // slower on AMD Zen5 CPUs.
     #define UNSET_BIT(i) \
       { \
         auto is_bit = (sieve[m] >> i) & 1; \
         sieve[m] &= ~(1 << i); \
-        uint64_t bucket = m >> counter_log2_dist; \
-        if (bucket > cur_bucket) \
+        if (m >= bucket_threshold) \
         { \
-          counter[cur_bucket] -= uint32_t(bucket_count); \
-          cur_bucket = bucket; \
+          counter[(bucket_threshold >> counter_log2_dist) - 1] -= uint32_t(bucket_count); \
+          bucket_threshold = ((m >> counter_log2_dist) + 1) << counter_log2_dist; \
           count += bucket_count; \
           bucket_count = 0; \
         } \
@@ -672,6 +679,7 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
 
     finished1:;
 
+    uint64_t cur_bucket = (bucket_threshold >> counter_log2_dist) - 1;
     if (cur_bucket < counter_size_)
       counter[cur_bucket] -= uint32_t(bucket_count);
 

--- a/src/Sieve.cpp
+++ b/src/Sieve.cpp
@@ -168,7 +168,7 @@ void Sieve::init_counter(uint64_t low, uint64_t high)
 {
   reset_counter();
   total_count_ = 0;
-  many_hits_threshold_ = counter_.counter.size() * 8;
+  many_hits_threshold_ = counter_.counter.size() * 4;
   many_hits_per_bucket_ = true;
 
   uint64_t start = 0;

--- a/src/Sieve.cpp
+++ b/src/Sieve.cpp
@@ -526,8 +526,8 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
 
   if (many_hits_per_bucket_)
   {
-    uint64_t bucket_count = 0;
     uint64_t cur_bucket = m >> counter_log2_dist;
+    uint64_t bucket_count = 0;
 
     #define CHECK_FINISHED(w) \
       if_unlikely(m >= sieve_bytes) \
@@ -538,16 +538,15 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
 
     #define UNSET_BIT(i) \
       { \
-        std::size_t sieve_byte = sieve[m]; \
-        std::size_t is_bit = (sieve_byte >> i) & 1; \
+        auto is_bit = (sieve[m] >> i) & 1; \
         sieve[m] &= ~(1 << i); \
         uint64_t bucket = m >> counter_log2_dist; \
         if (bucket > cur_bucket) \
         { \
           counter[cur_bucket] -= uint32_t(bucket_count); \
+          cur_bucket = bucket; \
           count += bucket_count; \
           bucket_count = 0; \
-          cur_bucket = bucket; \
         } \
         bucket_count += is_bit; \
       }

--- a/src/Sieve.cpp
+++ b/src/Sieve.cpp
@@ -508,7 +508,7 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
   uint64_t wheel_index = primeState.wheel_index;
   uint64_t g = wheel_index / 8;
   uint64_t m = primeState.multiple;
-  uint64_t total_count = total_count_;
+  uint64_t count = 0;
   uint64_t counter_log2_dist = counter_.log2_dist;
   uint32_t* counter = &counter_[0];
   uint8_t* sieve = (uint8_t*) &sieve_[0];
@@ -527,12 +527,10 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
   {
     uint64_t bucket_delta = 0;
     uint64_t cur_bucket = m >> counter_log2_dist;
-    uint64_t old_total_count = total_count;
 
     #define CHECK_FINISHED(w) \
       if_unlikely(m >= sieve_bytes) \
       { \
-        counter[cur_bucket] -= uint32_t(bucket_delta); \
         primeState.wheel_index = w; \
         goto finished; \
       }
@@ -546,7 +544,7 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
         if (bucket != cur_bucket) \
         { \
           counter[cur_bucket] -= uint32_t(bucket_delta); \
-          total_count -= bucket_delta; \
+          count += bucket_delta; \
           bucket_delta = 0; \
           cur_bucket = bucket; \
         } \
@@ -659,10 +657,12 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
     #undef CHECK_FINISHED
 
     finished:;
-    primeState.multiple = uint32_t(m - sieve_bytes); \
-    total_count -= bucket_delta; \
-    total_count_ = total_count; \
-    many_hits_per_bucket_ = (old_total_count - total_count) / 8 >= counter_.counter.size();
+
+    counter[cur_bucket] -= uint32_t(bucket_delta); \
+    primeState.multiple = uint32_t(m - sieve_bytes);
+    count += bucket_delta;
+    total_count_ -= count;
+    many_hits_per_bucket_ = count / 8 >= counter_.counter.size();
   }
   else
   {
@@ -671,7 +671,7 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
       { \
         primeState.wheel_index = w; \
         primeState.multiple = uint32_t(m - sieve_bytes); \
-        total_count_ = total_count; \
+        total_count_ -= count; \
         return; \
       }
 
@@ -681,7 +681,7 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
         std::size_t is_bit = (sieve_byte >> i) & 1; \
         sieve[m] &= ~(1 << i); \
         counter[m >> counter_log2_dist] -= uint32_t(is_bit); \
-        total_count -= uint64_t(is_bit); \
+        count += uint64_t(is_bit); \
       }
 
     ASSERT (wheel_index <= 63);

--- a/src/Sieve.cpp
+++ b/src/Sieve.cpp
@@ -504,17 +504,21 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
   if (i >= primeState_.size())
     add(prime, i);
 
-  prime /= 30;
   PrimeState& primeState = primeState_[i];
   uint64_t wheel_index = primeState.wheel_index;
   uint64_t g = wheel_index / 8;
   uint64_t m = primeState.multiple;
-  uint64_t count = 0;
-  uint64_t counter_log2_dist = counter_.log2_dist;
-  uint32_t* counter = &counter_[0];
   uint8_t* sieve = (uint8_t*) &sieve_[0];
   uint64_t sieve_bytes = sieve_.size() * 8;
 
+  if (m >= sieve_bytes)
+  {
+    uint32_t m32 = uint32_t(m - sieve_bytes);
+    primeState.multiple = m32;
+    return;
+  }
+
+  prime /= 30;
   uint64_t adv0 = prime * 6 + wheel_corr[g][0];
   uint64_t adv1 = prime * 4 + wheel_corr[g][1];
   uint64_t adv2 = prime * 2 + wheel_corr[g][2];
@@ -523,6 +527,10 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
   uint64_t adv5 = prime * 4 + wheel_corr[g][5];
   uint64_t adv6 = prime * 6 + wheel_corr[g][6];
   uint64_t adv7 = prime * 2 + wheel_corr[g][7];
+
+  uint64_t count = 0;
+  uint64_t counter_log2_dist = counter_.log2_dist;
+  uint32_t* counter = &counter_[0];
 
   if (many_hits_per_bucket_)
   {
@@ -658,8 +666,8 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
 
     finished:;
 
-    counter[cur_bucket] -= uint32_t(bucket_count);
     primeState.multiple = uint32_t(m - sieve_bytes);
+    counter[cur_bucket] -= uint32_t(bucket_count);
     count += bucket_count;
     total_count_ -= count;
     many_hits_per_bucket_ = (count >= many_hits_threshold_);

--- a/src/Sieve.cpp
+++ b/src/Sieve.cpp
@@ -530,18 +530,19 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
   uint64_t adv6 = prime * 6 + wheel_corr[g][6];
   uint64_t adv7 = prime * 2 + wheel_corr[g][7];
 
-  // A small sieving prime hits the same counter array bucket
-  // many times in a row. Decrementing counter[bucket] on each
-  // hit is a read-modify-write to the same address, so on
+  // A small sieving prime hits the same counter array element
+  // many times in a row. Decrementing counter[c] on each hit
+  // is a read-modify-write to the same address, so on
   // out-of-order CPUs the hits serialize on store-to-load
   // forwarding latency. Hence, for such small primes we use an
-  // alternative algorithm that avoids this by accumulating a
-  // bucket's hits in a register, writing counter[bucket] back
-  // only once per bucket.
+  // alternative algorithm that avoids this by accumulating the
+  // count in a register, subtracting from counter[c] only
+  // once when the counter index c increases.
   if (is_small_prime)
   {
-    uint64_t bucket_threshold = ((m >> counter_log2_dist) + 1) << counter_log2_dist;
-    uint64_t bucket_count = 0;
+    uint64_t delta_count = 0;
+    uint64_t counter_threshold = 
+        ((m >> counter_log2_dist) + 1) << counter_log2_dist;
 
     #define CHECK_FINISHED(w) \
       if (m >= sieve_bytes) \
@@ -550,26 +551,19 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
         goto finished1; \
       }
 
-    // bucket_threshold is the byte offset where the current bucket
-    // ends. Comparing m against it avoids recomputing the bucket index
-    // (m >> counter_log2_dist) on every hit. We deliberately carry only
-    // this single loop variable and recompute cur_bucket from it in the
-    // rarely taken branch below: carrying both cur_bucket and
-    // bucket_threshold adds an extra live value that makes GCC 16 spill
-    // in the inner loop (worst with -march=znver5), which is up to 10%
-    // slower on AMD Zen5 CPUs.
     #define UNSET_BIT(i) \
       { \
         auto is_bit = (sieve[m] >> i) & 1; \
         sieve[m] &= ~(1 << i); \
-        if (m >= bucket_threshold) \
+        if (m >= counter_threshold) \
         { \
-          counter[(bucket_threshold >> counter_log2_dist) - 1] -= uint32_t(bucket_count); \
-          bucket_threshold = ((m >> counter_log2_dist) + 1) << counter_log2_dist; \
-          count += bucket_count; \
-          bucket_count = 0; \
+          auto c = (counter_threshold >> counter_log2_dist) - 1; \
+          counter[c] -= uint32_t(delta_count); \
+          counter_threshold = ((m >> counter_log2_dist) + 1) << counter_log2_dist; \
+          count += delta_count; \
+          delta_count = 0; \
         } \
-        bucket_count += is_bit; \
+        delta_count += is_bit; \
       }
 
     ASSERT (wheel_index <= 63);
@@ -679,12 +673,12 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
 
     finished1:;
 
-    uint64_t cur_bucket = (bucket_threshold >> counter_log2_dist) - 1;
-    if (cur_bucket < counter_size_)
-      counter[cur_bucket] -= uint32_t(bucket_count);
+    uint64_t c = (counter_threshold >> counter_log2_dist) - 1;
+    if (c < counter_size_)
+      counter[c] -= uint32_t(delta_count);
 
     primeState.multiple = uint32_t(m - sieve_bytes);
-    count += bucket_count;
+    count += delta_count;
     total_count_ -= count;
   }
   else

--- a/src/Sieve.cpp
+++ b/src/Sieve.cpp
@@ -539,10 +539,7 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
 
     #define CHECK_FINISHED(w) \
       if (m >= sieve_bytes) \
-      { \
-        primeState.wheel_index = w; \
-        goto finished1; \
-      }
+        goto finished1_ ## w;
 
     #define UNSET_BIT(i) \
       { \
@@ -664,6 +661,78 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
     #undef UNSET_BIT
     #undef CHECK_FINISHED
 
+    finished1_0:;  primeState.wheel_index = 0;  goto finished1;
+    finished1_1:;  primeState.wheel_index = 1;  goto finished1;
+    finished1_2:;  primeState.wheel_index = 2;  goto finished1;
+    finished1_3:;  primeState.wheel_index = 3;  goto finished1;
+    finished1_4:;  primeState.wheel_index = 4;  goto finished1;
+    finished1_5:;  primeState.wheel_index = 5;  goto finished1;
+    finished1_6:;  primeState.wheel_index = 6;  goto finished1;
+    finished1_7:;  primeState.wheel_index = 7;  goto finished1;
+
+    finished1_8:;  primeState.wheel_index = 8;  goto finished1;
+    finished1_9:;  primeState.wheel_index = 9;  goto finished1;
+    finished1_10:; primeState.wheel_index = 10; goto finished1;
+    finished1_11:; primeState.wheel_index = 11; goto finished1;
+    finished1_12:; primeState.wheel_index = 12; goto finished1;
+    finished1_13:; primeState.wheel_index = 13; goto finished1;
+    finished1_14:; primeState.wheel_index = 14; goto finished1;
+    finished1_15:; primeState.wheel_index = 15; goto finished1;
+
+    finished1_16:; primeState.wheel_index = 16; goto finished1;
+    finished1_17:; primeState.wheel_index = 17; goto finished1;
+    finished1_18:; primeState.wheel_index = 18; goto finished1;
+    finished1_19:; primeState.wheel_index = 19; goto finished1;
+    finished1_20:; primeState.wheel_index = 20; goto finished1;
+    finished1_21:; primeState.wheel_index = 21; goto finished1;
+    finished1_22:; primeState.wheel_index = 22; goto finished1;
+    finished1_23:; primeState.wheel_index = 23; goto finished1;
+
+    finished1_24:; primeState.wheel_index = 24; goto finished1;
+    finished1_25:; primeState.wheel_index = 25; goto finished1;
+    finished1_26:; primeState.wheel_index = 26; goto finished1;
+    finished1_27:; primeState.wheel_index = 27; goto finished1;
+    finished1_28:; primeState.wheel_index = 28; goto finished1;
+    finished1_29:; primeState.wheel_index = 29; goto finished1;
+    finished1_30:; primeState.wheel_index = 30; goto finished1;
+    finished1_31:; primeState.wheel_index = 31; goto finished1;
+
+    finished1_32:; primeState.wheel_index = 32; goto finished1;
+    finished1_33:; primeState.wheel_index = 33; goto finished1;
+    finished1_34:; primeState.wheel_index = 34; goto finished1;
+    finished1_35:; primeState.wheel_index = 35; goto finished1;
+    finished1_36:; primeState.wheel_index = 36; goto finished1;
+    finished1_37:; primeState.wheel_index = 37; goto finished1;
+    finished1_38:; primeState.wheel_index = 38; goto finished1;
+    finished1_39:; primeState.wheel_index = 39; goto finished1;
+
+    finished1_40:; primeState.wheel_index = 40; goto finished1;
+    finished1_41:; primeState.wheel_index = 41; goto finished1;
+    finished1_42:; primeState.wheel_index = 42; goto finished1;
+    finished1_43:; primeState.wheel_index = 43; goto finished1;
+    finished1_44:; primeState.wheel_index = 44; goto finished1;
+    finished1_45:; primeState.wheel_index = 45; goto finished1;
+    finished1_46:; primeState.wheel_index = 46; goto finished1;
+    finished1_47:; primeState.wheel_index = 47; goto finished1;
+
+    finished1_48:; primeState.wheel_index = 48; goto finished1;
+    finished1_49:; primeState.wheel_index = 49; goto finished1;
+    finished1_50:; primeState.wheel_index = 50; goto finished1;
+    finished1_51:; primeState.wheel_index = 51; goto finished1;
+    finished1_52:; primeState.wheel_index = 52; goto finished1;
+    finished1_53:; primeState.wheel_index = 53; goto finished1;
+    finished1_54:; primeState.wheel_index = 54; goto finished1;
+    finished1_55:; primeState.wheel_index = 55; goto finished1;
+
+    finished1_56:; primeState.wheel_index = 56; goto finished1;
+    finished1_57:; primeState.wheel_index = 57; goto finished1;
+    finished1_58:; primeState.wheel_index = 58; goto finished1;
+    finished1_59:; primeState.wheel_index = 59; goto finished1;
+    finished1_60:; primeState.wheel_index = 60; goto finished1;
+    finished1_61:; primeState.wheel_index = 61; goto finished1;
+    finished1_62:; primeState.wheel_index = 62; goto finished1;
+    finished1_63:; primeState.wheel_index = 63; goto finished1;
+
     finished1:;
 
     primeState.multiple = uint32_t(m - sieve_bytes);
@@ -676,10 +745,7 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
   {
     #define CHECK_FINISHED(w) \
       if (m >= sieve_bytes) \
-      { \
-        primeState.wheel_index = w; \
-        goto finished2; \
-      }
+        goto finished2_ ## w;
 
     #define UNSET_BIT(i) \
       { \
@@ -791,6 +857,78 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
 
       default: UNREACHABLE;
     }
+
+    finished2_0:;  primeState.wheel_index = 0;  goto finished2;
+    finished2_1:;  primeState.wheel_index = 1;  goto finished2;
+    finished2_2:;  primeState.wheel_index = 2;  goto finished2;
+    finished2_3:;  primeState.wheel_index = 3;  goto finished2;
+    finished2_4:;  primeState.wheel_index = 4;  goto finished2;
+    finished2_5:;  primeState.wheel_index = 5;  goto finished2;
+    finished2_6:;  primeState.wheel_index = 6;  goto finished2;
+    finished2_7:;  primeState.wheel_index = 7;  goto finished2;
+
+    finished2_8:;  primeState.wheel_index = 8;  goto finished2;
+    finished2_9:;  primeState.wheel_index = 9;  goto finished2;
+    finished2_10:; primeState.wheel_index = 10; goto finished2;
+    finished2_11:; primeState.wheel_index = 11; goto finished2;
+    finished2_12:; primeState.wheel_index = 12; goto finished2;
+    finished2_13:; primeState.wheel_index = 13; goto finished2;
+    finished2_14:; primeState.wheel_index = 14; goto finished2;
+    finished2_15:; primeState.wheel_index = 15; goto finished2;
+
+    finished2_16:; primeState.wheel_index = 16; goto finished2;
+    finished2_17:; primeState.wheel_index = 17; goto finished2;
+    finished2_18:; primeState.wheel_index = 18; goto finished2;
+    finished2_19:; primeState.wheel_index = 19; goto finished2;
+    finished2_20:; primeState.wheel_index = 20; goto finished2;
+    finished2_21:; primeState.wheel_index = 21; goto finished2;
+    finished2_22:; primeState.wheel_index = 22; goto finished2;
+    finished2_23:; primeState.wheel_index = 23; goto finished2;
+
+    finished2_24:; primeState.wheel_index = 24; goto finished2;
+    finished2_25:; primeState.wheel_index = 25; goto finished2;
+    finished2_26:; primeState.wheel_index = 26; goto finished2;
+    finished2_27:; primeState.wheel_index = 27; goto finished2;
+    finished2_28:; primeState.wheel_index = 28; goto finished2;
+    finished2_29:; primeState.wheel_index = 29; goto finished2;
+    finished2_30:; primeState.wheel_index = 30; goto finished2;
+    finished2_31:; primeState.wheel_index = 31; goto finished2;
+
+    finished2_32:; primeState.wheel_index = 32; goto finished2;
+    finished2_33:; primeState.wheel_index = 33; goto finished2;
+    finished2_34:; primeState.wheel_index = 34; goto finished2;
+    finished2_35:; primeState.wheel_index = 35; goto finished2;
+    finished2_36:; primeState.wheel_index = 36; goto finished2;
+    finished2_37:; primeState.wheel_index = 37; goto finished2;
+    finished2_38:; primeState.wheel_index = 38; goto finished2;
+    finished2_39:; primeState.wheel_index = 39; goto finished2;
+
+    finished2_40:; primeState.wheel_index = 40; goto finished2;
+    finished2_41:; primeState.wheel_index = 41; goto finished2;
+    finished2_42:; primeState.wheel_index = 42; goto finished2;
+    finished2_43:; primeState.wheel_index = 43; goto finished2;
+    finished2_44:; primeState.wheel_index = 44; goto finished2;
+    finished2_45:; primeState.wheel_index = 45; goto finished2;
+    finished2_46:; primeState.wheel_index = 46; goto finished2;
+    finished2_47:; primeState.wheel_index = 47; goto finished2;
+
+    finished2_48:; primeState.wheel_index = 48; goto finished2;
+    finished2_49:; primeState.wheel_index = 49; goto finished2;
+    finished2_50:; primeState.wheel_index = 50; goto finished2;
+    finished2_51:; primeState.wheel_index = 51; goto finished2;
+    finished2_52:; primeState.wheel_index = 52; goto finished2;
+    finished2_53:; primeState.wheel_index = 53; goto finished2;
+    finished2_54:; primeState.wheel_index = 54; goto finished2;
+    finished2_55:; primeState.wheel_index = 55; goto finished2;
+
+    finished2_56:; primeState.wheel_index = 56; goto finished2;
+    finished2_57:; primeState.wheel_index = 57; goto finished2;
+    finished2_58:; primeState.wheel_index = 58; goto finished2;
+    finished2_59:; primeState.wheel_index = 59; goto finished2;
+    finished2_60:; primeState.wheel_index = 60; goto finished2;
+    finished2_61:; primeState.wheel_index = 61; goto finished2;
+    finished2_62:; primeState.wheel_index = 62; goto finished2;
+    finished2_63:; primeState.wheel_index = 63; goto finished2;
 
     finished2:;
 

--- a/src/Sieve.cpp
+++ b/src/Sieve.cpp
@@ -532,6 +532,14 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
   uint64_t counter_log2_dist = counter_.log2_dist;
   uint32_t* counter = &counter_[0];
 
+  // A small sieving prime hits the same counter array bucket
+  // many times in a row. Decrementing counter[bucket] on each
+  // hit is a read-modify-write to the same address, so on
+  // out-of-order CPUs the hits serialize on store-to-load
+  // forwarding latency. Hence, for such small primes we use an
+  // alternative algorithm that avoids this by accumulating a
+  // bucket's hits in a register, writing counter[bucket] back
+  // only once per bucket.
   if (many_hits_per_bucket_)
   {
     uint64_t cur_bucket = m >> counter_log2_dist;

--- a/src/Sieve.cpp
+++ b/src/Sieve.cpp
@@ -168,6 +168,7 @@ void Sieve::init_counter(uint64_t low, uint64_t high)
 {
   reset_counter();
   total_count_ = 0;
+  many_hits_threshold_ = counter_.counter.size() * 8;
   many_hits_per_bucket_ = true;
 
   uint64_t start = 0;
@@ -525,7 +526,7 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
 
   if (many_hits_per_bucket_)
   {
-    uint64_t bucket_delta = 0;
+    uint64_t bucket_count = 0;
     uint64_t cur_bucket = m >> counter_log2_dist;
 
     #define CHECK_FINISHED(w) \
@@ -543,12 +544,12 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
         uint64_t bucket = m >> counter_log2_dist; \
         if (bucket > cur_bucket) \
         { \
-          counter[cur_bucket] -= uint32_t(bucket_delta); \
-          count += bucket_delta; \
-          bucket_delta = 0; \
+          counter[cur_bucket] -= uint32_t(bucket_count); \
+          count += bucket_count; \
+          bucket_count = 0; \
           cur_bucket = bucket; \
         } \
-        bucket_delta += is_bit; \
+        bucket_count += is_bit; \
       }
 
     ASSERT (wheel_index <= 63);
@@ -658,11 +659,11 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
 
     finished:;
 
-    counter[cur_bucket] -= uint32_t(bucket_delta); \
+    counter[cur_bucket] -= uint32_t(bucket_count);
     primeState.multiple = uint32_t(m - sieve_bytes);
-    count += bucket_delta;
+    many_hits_per_bucket_ = (count >= many_hits_threshold_);
+    count += bucket_count;
     total_count_ -= count;
-    many_hits_per_bucket_ = count / 8 >= counter_.counter.size();
   }
   else
   {

--- a/src/Sieve.cpp
+++ b/src/Sieve.cpp
@@ -168,7 +168,7 @@ void Sieve::init_counter(uint64_t low, uint64_t high)
 {
   reset_counter();
   total_count_ = 0;
-  many_hits_threshold_ = counter_.counter.size() * 4;
+  many_hits_threshold_ = counter_.counter.size() * 2;
   many_hits_per_bucket_ = true;
 
   uint64_t start = 0;

--- a/src/Sieve.cpp
+++ b/src/Sieve.cpp
@@ -168,6 +168,7 @@ void Sieve::init_counter(uint64_t low, uint64_t high)
 {
   reset_counter();
   total_count_ = 0;
+  many_hits_per_bucket_ = true;
 
   uint64_t start = 0;
   uint64_t max_stop = (high - 1) - low;
@@ -512,6 +513,7 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
   uint32_t* counter = &counter_[0];
   uint8_t* sieve = (uint8_t*) &sieve_[0];
   uint64_t sieve_bytes = sieve_.size() * 8;
+
   uint64_t adv0 = prime * 6 + wheel_corr[g][0];
   uint64_t adv1 = prime * 4 + wheel_corr[g][1];
   uint64_t adv2 = prime * 2 + wheel_corr[g][2];
@@ -521,124 +523,268 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
   uint64_t adv6 = prime * 6 + wheel_corr[g][6];
   uint64_t adv7 = prime * 2 + wheel_corr[g][7];
 
-  #define CHECK_FINISHED(w) \
-    if_unlikely(m >= sieve_bytes) \
-    { \
-      primeState.wheel_index = w; \
-      primeState.multiple = uint32_t(m - sieve_bytes); \
-      total_count_ = total_count; \
-      return; \
-    }
-
-  #define UNSET_BIT(i) \
-    { \
-      std::size_t sieve_byte = sieve[m]; \
-      std::size_t is_bit = (sieve_byte >> i) & 1; \
-      sieve[m] &= ~(1 << i); \
-      counter[m >> counter_log2_dist] -= uint32_t(is_bit); \
-      total_count -= uint64_t(is_bit); \
-    }
-
-  ASSERT (wheel_index <= 63);
-  switch (wheel_index)
+  if (many_hits_per_bucket_)
   {
-    while (true)
+    uint64_t bucket_delta = 0;
+    uint64_t cur_bucket = m >> counter_log2_dist;
+    uint64_t old_total_count = total_count;
+
+    #define CHECK_FINISHED(w) \
+      if_unlikely(m >= sieve_bytes) \
+      { \
+        counter[cur_bucket] -= uint32_t(bucket_delta); \
+        primeState.wheel_index = w; \
+        goto finished; \
+      }
+
+    #define UNSET_BIT(i) \
+      { \
+        std::size_t sieve_byte = sieve[m]; \
+        std::size_t is_bit = (sieve_byte >> i) & 1; \
+        sieve[m] &= ~(1 << i); \
+        uint64_t bucket = m >> counter_log2_dist; \
+        if (bucket != cur_bucket) \
+        { \
+          counter[cur_bucket] -= uint32_t(bucket_delta); \
+          total_count -= bucket_delta; \
+          bucket_delta = 0; \
+          cur_bucket = bucket; \
+        } \
+        bucket_delta += is_bit; \
+      }
+
+    ASSERT (wheel_index <= 63);
+    switch (wheel_index)
     {
-      case 0: CHECK_FINISHED(0); UNSET_BIT(0); m += adv0; FALLTHROUGH;
-      case 1: CHECK_FINISHED(1); UNSET_BIT(1); m += adv1; FALLTHROUGH;
-      case 2: CHECK_FINISHED(2); UNSET_BIT(2); m += adv2; FALLTHROUGH;
-      case 3: CHECK_FINISHED(3); UNSET_BIT(3); m += adv3; FALLTHROUGH;
-      case 4: CHECK_FINISHED(4); UNSET_BIT(4); m += adv4; FALLTHROUGH;
-      case 5: CHECK_FINISHED(5); UNSET_BIT(5); m += adv5; FALLTHROUGH;
-      case 6: CHECK_FINISHED(6); UNSET_BIT(6); m += adv6; FALLTHROUGH;
-      case 7: CHECK_FINISHED(7); UNSET_BIT(7); m += adv7;
+      while (true)
+      {
+        case 0: CHECK_FINISHED(0); UNSET_BIT(0); m += adv0; FALLTHROUGH;
+        case 1: CHECK_FINISHED(1); UNSET_BIT(1); m += adv1; FALLTHROUGH;
+        case 2: CHECK_FINISHED(2); UNSET_BIT(2); m += adv2; FALLTHROUGH;
+        case 3: CHECK_FINISHED(3); UNSET_BIT(3); m += adv3; FALLTHROUGH;
+        case 4: CHECK_FINISHED(4); UNSET_BIT(4); m += adv4; FALLTHROUGH;
+        case 5: CHECK_FINISHED(5); UNSET_BIT(5); m += adv5; FALLTHROUGH;
+        case 6: CHECK_FINISHED(6); UNSET_BIT(6); m += adv6; FALLTHROUGH;
+        case 7: CHECK_FINISHED(7); UNSET_BIT(7); m += adv7;
+      }
+
+      while (true)
+      {
+        case  8: CHECK_FINISHED( 8); UNSET_BIT(1); m += adv0; FALLTHROUGH;
+        case  9: CHECK_FINISHED( 9); UNSET_BIT(5); m += adv1; FALLTHROUGH;
+        case 10: CHECK_FINISHED(10); UNSET_BIT(4); m += adv2; FALLTHROUGH;
+        case 11: CHECK_FINISHED(11); UNSET_BIT(0); m += adv3; FALLTHROUGH;
+        case 12: CHECK_FINISHED(12); UNSET_BIT(7); m += adv4; FALLTHROUGH;
+        case 13: CHECK_FINISHED(13); UNSET_BIT(3); m += adv5; FALLTHROUGH;
+        case 14: CHECK_FINISHED(14); UNSET_BIT(2); m += adv6; FALLTHROUGH;
+        case 15: CHECK_FINISHED(15); UNSET_BIT(6); m += adv7;
+      }
+
+      while (true)
+      {
+        case 16: CHECK_FINISHED(16); UNSET_BIT(2); m += adv0; FALLTHROUGH;
+        case 17: CHECK_FINISHED(17); UNSET_BIT(4); m += adv1; FALLTHROUGH;
+        case 18: CHECK_FINISHED(18); UNSET_BIT(0); m += adv2; FALLTHROUGH;
+        case 19: CHECK_FINISHED(19); UNSET_BIT(6); m += adv3; FALLTHROUGH;
+        case 20: CHECK_FINISHED(20); UNSET_BIT(1); m += adv4; FALLTHROUGH;
+        case 21: CHECK_FINISHED(21); UNSET_BIT(7); m += adv5; FALLTHROUGH;
+        case 22: CHECK_FINISHED(22); UNSET_BIT(3); m += adv6; FALLTHROUGH;
+        case 23: CHECK_FINISHED(23); UNSET_BIT(5); m += adv7;
+      }
+
+      while (true)
+      {
+        case 24: CHECK_FINISHED(24); UNSET_BIT(3); m += adv0; FALLTHROUGH;
+        case 25: CHECK_FINISHED(25); UNSET_BIT(0); m += adv1; FALLTHROUGH;
+        case 26: CHECK_FINISHED(26); UNSET_BIT(6); m += adv2; FALLTHROUGH;
+        case 27: CHECK_FINISHED(27); UNSET_BIT(5); m += adv3; FALLTHROUGH;
+        case 28: CHECK_FINISHED(28); UNSET_BIT(2); m += adv4; FALLTHROUGH;
+        case 29: CHECK_FINISHED(29); UNSET_BIT(1); m += adv5; FALLTHROUGH;
+        case 30: CHECK_FINISHED(30); UNSET_BIT(7); m += adv6; FALLTHROUGH;
+        case 31: CHECK_FINISHED(31); UNSET_BIT(4); m += adv7;
+      }
+
+      while (true)
+      {
+        case 32: CHECK_FINISHED(32); UNSET_BIT(4); m += adv0; FALLTHROUGH;
+        case 33: CHECK_FINISHED(33); UNSET_BIT(7); m += adv1; FALLTHROUGH;
+        case 34: CHECK_FINISHED(34); UNSET_BIT(1); m += adv2; FALLTHROUGH;
+        case 35: CHECK_FINISHED(35); UNSET_BIT(2); m += adv3; FALLTHROUGH;
+        case 36: CHECK_FINISHED(36); UNSET_BIT(5); m += adv4; FALLTHROUGH;
+        case 37: CHECK_FINISHED(37); UNSET_BIT(6); m += adv5; FALLTHROUGH;
+        case 38: CHECK_FINISHED(38); UNSET_BIT(0); m += adv6; FALLTHROUGH;
+        case 39: CHECK_FINISHED(39); UNSET_BIT(3); m += adv7;
+      }
+
+      while (true)
+      {
+        case 40: CHECK_FINISHED(40); UNSET_BIT(5); m += adv0; FALLTHROUGH;
+        case 41: CHECK_FINISHED(41); UNSET_BIT(3); m += adv1; FALLTHROUGH;
+        case 42: CHECK_FINISHED(42); UNSET_BIT(7); m += adv2; FALLTHROUGH;
+        case 43: CHECK_FINISHED(43); UNSET_BIT(1); m += adv3; FALLTHROUGH;
+        case 44: CHECK_FINISHED(44); UNSET_BIT(6); m += adv4; FALLTHROUGH;
+        case 45: CHECK_FINISHED(45); UNSET_BIT(0); m += adv5; FALLTHROUGH;
+        case 46: CHECK_FINISHED(46); UNSET_BIT(4); m += adv6; FALLTHROUGH;
+        case 47: CHECK_FINISHED(47); UNSET_BIT(2); m += adv7;
+      }
+
+      while (true)
+      {
+        case 48: CHECK_FINISHED(48); UNSET_BIT(6); m += adv0; FALLTHROUGH;
+        case 49: CHECK_FINISHED(49); UNSET_BIT(2); m += adv1; FALLTHROUGH;
+        case 50: CHECK_FINISHED(50); UNSET_BIT(3); m += adv2; FALLTHROUGH;
+        case 51: CHECK_FINISHED(51); UNSET_BIT(7); m += adv3; FALLTHROUGH;
+        case 52: CHECK_FINISHED(52); UNSET_BIT(0); m += adv4; FALLTHROUGH;
+        case 53: CHECK_FINISHED(53); UNSET_BIT(4); m += adv5; FALLTHROUGH;
+        case 54: CHECK_FINISHED(54); UNSET_BIT(5); m += adv6; FALLTHROUGH;
+        case 55: CHECK_FINISHED(55); UNSET_BIT(1); m += adv7;
+      }
+
+      while (true)
+      {
+        case 56: CHECK_FINISHED(56); UNSET_BIT(7); m += adv0; FALLTHROUGH;
+        case 57: CHECK_FINISHED(57); UNSET_BIT(6); m += adv1; FALLTHROUGH;
+        case 58: CHECK_FINISHED(58); UNSET_BIT(5); m += adv2; FALLTHROUGH;
+        case 59: CHECK_FINISHED(59); UNSET_BIT(4); m += adv3; FALLTHROUGH;
+        case 60: CHECK_FINISHED(60); UNSET_BIT(3); m += adv4; FALLTHROUGH;
+        case 61: CHECK_FINISHED(61); UNSET_BIT(2); m += adv5; FALLTHROUGH;
+        case 62: CHECK_FINISHED(62); UNSET_BIT(1); m += adv6; FALLTHROUGH;
+        case 63: CHECK_FINISHED(63); UNSET_BIT(0); m += adv7;
+      }
+
+      default: UNREACHABLE;
     }
 
-    while (true)
-    {
-      case  8: CHECK_FINISHED( 8); UNSET_BIT(1); m += adv0; FALLTHROUGH;
-      case  9: CHECK_FINISHED( 9); UNSET_BIT(5); m += adv1; FALLTHROUGH;
-      case 10: CHECK_FINISHED(10); UNSET_BIT(4); m += adv2; FALLTHROUGH;
-      case 11: CHECK_FINISHED(11); UNSET_BIT(0); m += adv3; FALLTHROUGH;
-      case 12: CHECK_FINISHED(12); UNSET_BIT(7); m += adv4; FALLTHROUGH;
-      case 13: CHECK_FINISHED(13); UNSET_BIT(3); m += adv5; FALLTHROUGH;
-      case 14: CHECK_FINISHED(14); UNSET_BIT(2); m += adv6; FALLTHROUGH;
-      case 15: CHECK_FINISHED(15); UNSET_BIT(6); m += adv7;
-    }
+    #undef UNSET_BIT
+    #undef CHECK_FINISHED
 
-    while (true)
-    {
-      case 16: CHECK_FINISHED(16); UNSET_BIT(2); m += adv0; FALLTHROUGH;
-      case 17: CHECK_FINISHED(17); UNSET_BIT(4); m += adv1; FALLTHROUGH;
-      case 18: CHECK_FINISHED(18); UNSET_BIT(0); m += adv2; FALLTHROUGH;
-      case 19: CHECK_FINISHED(19); UNSET_BIT(6); m += adv3; FALLTHROUGH;
-      case 20: CHECK_FINISHED(20); UNSET_BIT(1); m += adv4; FALLTHROUGH;
-      case 21: CHECK_FINISHED(21); UNSET_BIT(7); m += adv5; FALLTHROUGH;
-      case 22: CHECK_FINISHED(22); UNSET_BIT(3); m += adv6; FALLTHROUGH;
-      case 23: CHECK_FINISHED(23); UNSET_BIT(5); m += adv7;
-    }
+    finished:;
+    primeState.multiple = uint32_t(m - sieve_bytes); \
+    total_count -= bucket_delta; \
+    total_count_ = total_count; \
+    many_hits_per_bucket_ = (old_total_count - total_count) / 8 >= counter_.counter.size();
+  }
+  else
+  {
+    #define CHECK_FINISHED(w) \
+      if_unlikely(m >= sieve_bytes) \
+      { \
+        primeState.wheel_index = w; \
+        primeState.multiple = uint32_t(m - sieve_bytes); \
+        total_count_ = total_count; \
+        return; \
+      }
 
-    while (true)
-    {
-      case 24: CHECK_FINISHED(24); UNSET_BIT(3); m += adv0; FALLTHROUGH;
-      case 25: CHECK_FINISHED(25); UNSET_BIT(0); m += adv1; FALLTHROUGH;
-      case 26: CHECK_FINISHED(26); UNSET_BIT(6); m += adv2; FALLTHROUGH;
-      case 27: CHECK_FINISHED(27); UNSET_BIT(5); m += adv3; FALLTHROUGH;
-      case 28: CHECK_FINISHED(28); UNSET_BIT(2); m += adv4; FALLTHROUGH;
-      case 29: CHECK_FINISHED(29); UNSET_BIT(1); m += adv5; FALLTHROUGH;
-      case 30: CHECK_FINISHED(30); UNSET_BIT(7); m += adv6; FALLTHROUGH;
-      case 31: CHECK_FINISHED(31); UNSET_BIT(4); m += adv7;
-    }
+    #define UNSET_BIT(i) \
+      { \
+        std::size_t sieve_byte = sieve[m]; \
+        std::size_t is_bit = (sieve_byte >> i) & 1; \
+        sieve[m] &= ~(1 << i); \
+        counter[m >> counter_log2_dist] -= uint32_t(is_bit); \
+        total_count -= uint64_t(is_bit); \
+      }
 
-    while (true)
+    ASSERT (wheel_index <= 63);
+    switch (wheel_index)
     {
-      case 32: CHECK_FINISHED(32); UNSET_BIT(4); m += adv0; FALLTHROUGH;
-      case 33: CHECK_FINISHED(33); UNSET_BIT(7); m += adv1; FALLTHROUGH;
-      case 34: CHECK_FINISHED(34); UNSET_BIT(1); m += adv2; FALLTHROUGH;
-      case 35: CHECK_FINISHED(35); UNSET_BIT(2); m += adv3; FALLTHROUGH;
-      case 36: CHECK_FINISHED(36); UNSET_BIT(5); m += adv4; FALLTHROUGH;
-      case 37: CHECK_FINISHED(37); UNSET_BIT(6); m += adv5; FALLTHROUGH;
-      case 38: CHECK_FINISHED(38); UNSET_BIT(0); m += adv6; FALLTHROUGH;
-      case 39: CHECK_FINISHED(39); UNSET_BIT(3); m += adv7;
-    }
+      while (true)
+      {
+        case 0: CHECK_FINISHED(0); UNSET_BIT(0); m += adv0; FALLTHROUGH;
+        case 1: CHECK_FINISHED(1); UNSET_BIT(1); m += adv1; FALLTHROUGH;
+        case 2: CHECK_FINISHED(2); UNSET_BIT(2); m += adv2; FALLTHROUGH;
+        case 3: CHECK_FINISHED(3); UNSET_BIT(3); m += adv3; FALLTHROUGH;
+        case 4: CHECK_FINISHED(4); UNSET_BIT(4); m += adv4; FALLTHROUGH;
+        case 5: CHECK_FINISHED(5); UNSET_BIT(5); m += adv5; FALLTHROUGH;
+        case 6: CHECK_FINISHED(6); UNSET_BIT(6); m += adv6; FALLTHROUGH;
+        case 7: CHECK_FINISHED(7); UNSET_BIT(7); m += adv7;
+      }
 
-    while (true)
-    {
-      case 40: CHECK_FINISHED(40); UNSET_BIT(5); m += adv0; FALLTHROUGH;
-      case 41: CHECK_FINISHED(41); UNSET_BIT(3); m += adv1; FALLTHROUGH;
-      case 42: CHECK_FINISHED(42); UNSET_BIT(7); m += adv2; FALLTHROUGH;
-      case 43: CHECK_FINISHED(43); UNSET_BIT(1); m += adv3; FALLTHROUGH;
-      case 44: CHECK_FINISHED(44); UNSET_BIT(6); m += adv4; FALLTHROUGH;
-      case 45: CHECK_FINISHED(45); UNSET_BIT(0); m += adv5; FALLTHROUGH;
-      case 46: CHECK_FINISHED(46); UNSET_BIT(4); m += adv6; FALLTHROUGH;
-      case 47: CHECK_FINISHED(47); UNSET_BIT(2); m += adv7;
-    }
+      while (true)
+      {
+        case  8: CHECK_FINISHED( 8); UNSET_BIT(1); m += adv0; FALLTHROUGH;
+        case  9: CHECK_FINISHED( 9); UNSET_BIT(5); m += adv1; FALLTHROUGH;
+        case 10: CHECK_FINISHED(10); UNSET_BIT(4); m += adv2; FALLTHROUGH;
+        case 11: CHECK_FINISHED(11); UNSET_BIT(0); m += adv3; FALLTHROUGH;
+        case 12: CHECK_FINISHED(12); UNSET_BIT(7); m += adv4; FALLTHROUGH;
+        case 13: CHECK_FINISHED(13); UNSET_BIT(3); m += adv5; FALLTHROUGH;
+        case 14: CHECK_FINISHED(14); UNSET_BIT(2); m += adv6; FALLTHROUGH;
+        case 15: CHECK_FINISHED(15); UNSET_BIT(6); m += adv7;
+      }
 
-    while (true)
-    {
-      case 48: CHECK_FINISHED(48); UNSET_BIT(6); m += adv0; FALLTHROUGH;
-      case 49: CHECK_FINISHED(49); UNSET_BIT(2); m += adv1; FALLTHROUGH;
-      case 50: CHECK_FINISHED(50); UNSET_BIT(3); m += adv2; FALLTHROUGH;
-      case 51: CHECK_FINISHED(51); UNSET_BIT(7); m += adv3; FALLTHROUGH;
-      case 52: CHECK_FINISHED(52); UNSET_BIT(0); m += adv4; FALLTHROUGH;
-      case 53: CHECK_FINISHED(53); UNSET_BIT(4); m += adv5; FALLTHROUGH;
-      case 54: CHECK_FINISHED(54); UNSET_BIT(5); m += adv6; FALLTHROUGH;
-      case 55: CHECK_FINISHED(55); UNSET_BIT(1); m += adv7;
-    }
+      while (true)
+      {
+        case 16: CHECK_FINISHED(16); UNSET_BIT(2); m += adv0; FALLTHROUGH;
+        case 17: CHECK_FINISHED(17); UNSET_BIT(4); m += adv1; FALLTHROUGH;
+        case 18: CHECK_FINISHED(18); UNSET_BIT(0); m += adv2; FALLTHROUGH;
+        case 19: CHECK_FINISHED(19); UNSET_BIT(6); m += adv3; FALLTHROUGH;
+        case 20: CHECK_FINISHED(20); UNSET_BIT(1); m += adv4; FALLTHROUGH;
+        case 21: CHECK_FINISHED(21); UNSET_BIT(7); m += adv5; FALLTHROUGH;
+        case 22: CHECK_FINISHED(22); UNSET_BIT(3); m += adv6; FALLTHROUGH;
+        case 23: CHECK_FINISHED(23); UNSET_BIT(5); m += adv7;
+      }
 
-    while (true)
-    {
-      case 56: CHECK_FINISHED(56); UNSET_BIT(7); m += adv0; FALLTHROUGH;
-      case 57: CHECK_FINISHED(57); UNSET_BIT(6); m += adv1; FALLTHROUGH;
-      case 58: CHECK_FINISHED(58); UNSET_BIT(5); m += adv2; FALLTHROUGH;
-      case 59: CHECK_FINISHED(59); UNSET_BIT(4); m += adv3; FALLTHROUGH;
-      case 60: CHECK_FINISHED(60); UNSET_BIT(3); m += adv4; FALLTHROUGH;
-      case 61: CHECK_FINISHED(61); UNSET_BIT(2); m += adv5; FALLTHROUGH;
-      case 62: CHECK_FINISHED(62); UNSET_BIT(1); m += adv6; FALLTHROUGH;
-      case 63: CHECK_FINISHED(63); UNSET_BIT(0); m += adv7;
-    }
+      while (true)
+      {
+        case 24: CHECK_FINISHED(24); UNSET_BIT(3); m += adv0; FALLTHROUGH;
+        case 25: CHECK_FINISHED(25); UNSET_BIT(0); m += adv1; FALLTHROUGH;
+        case 26: CHECK_FINISHED(26); UNSET_BIT(6); m += adv2; FALLTHROUGH;
+        case 27: CHECK_FINISHED(27); UNSET_BIT(5); m += adv3; FALLTHROUGH;
+        case 28: CHECK_FINISHED(28); UNSET_BIT(2); m += adv4; FALLTHROUGH;
+        case 29: CHECK_FINISHED(29); UNSET_BIT(1); m += adv5; FALLTHROUGH;
+        case 30: CHECK_FINISHED(30); UNSET_BIT(7); m += adv6; FALLTHROUGH;
+        case 31: CHECK_FINISHED(31); UNSET_BIT(4); m += adv7;
+      }
 
-    default: UNREACHABLE;
+      while (true)
+      {
+        case 32: CHECK_FINISHED(32); UNSET_BIT(4); m += adv0; FALLTHROUGH;
+        case 33: CHECK_FINISHED(33); UNSET_BIT(7); m += adv1; FALLTHROUGH;
+        case 34: CHECK_FINISHED(34); UNSET_BIT(1); m += adv2; FALLTHROUGH;
+        case 35: CHECK_FINISHED(35); UNSET_BIT(2); m += adv3; FALLTHROUGH;
+        case 36: CHECK_FINISHED(36); UNSET_BIT(5); m += adv4; FALLTHROUGH;
+        case 37: CHECK_FINISHED(37); UNSET_BIT(6); m += adv5; FALLTHROUGH;
+        case 38: CHECK_FINISHED(38); UNSET_BIT(0); m += adv6; FALLTHROUGH;
+        case 39: CHECK_FINISHED(39); UNSET_BIT(3); m += adv7;
+      }
+
+      while (true)
+      {
+        case 40: CHECK_FINISHED(40); UNSET_BIT(5); m += adv0; FALLTHROUGH;
+        case 41: CHECK_FINISHED(41); UNSET_BIT(3); m += adv1; FALLTHROUGH;
+        case 42: CHECK_FINISHED(42); UNSET_BIT(7); m += adv2; FALLTHROUGH;
+        case 43: CHECK_FINISHED(43); UNSET_BIT(1); m += adv3; FALLTHROUGH;
+        case 44: CHECK_FINISHED(44); UNSET_BIT(6); m += adv4; FALLTHROUGH;
+        case 45: CHECK_FINISHED(45); UNSET_BIT(0); m += adv5; FALLTHROUGH;
+        case 46: CHECK_FINISHED(46); UNSET_BIT(4); m += adv6; FALLTHROUGH;
+        case 47: CHECK_FINISHED(47); UNSET_BIT(2); m += adv7;
+      }
+
+      while (true)
+      {
+        case 48: CHECK_FINISHED(48); UNSET_BIT(6); m += adv0; FALLTHROUGH;
+        case 49: CHECK_FINISHED(49); UNSET_BIT(2); m += adv1; FALLTHROUGH;
+        case 50: CHECK_FINISHED(50); UNSET_BIT(3); m += adv2; FALLTHROUGH;
+        case 51: CHECK_FINISHED(51); UNSET_BIT(7); m += adv3; FALLTHROUGH;
+        case 52: CHECK_FINISHED(52); UNSET_BIT(0); m += adv4; FALLTHROUGH;
+        case 53: CHECK_FINISHED(53); UNSET_BIT(4); m += adv5; FALLTHROUGH;
+        case 54: CHECK_FINISHED(54); UNSET_BIT(5); m += adv6; FALLTHROUGH;
+        case 55: CHECK_FINISHED(55); UNSET_BIT(1); m += adv7;
+      }
+
+      while (true)
+      {
+        case 56: CHECK_FINISHED(56); UNSET_BIT(7); m += adv0; FALLTHROUGH;
+        case 57: CHECK_FINISHED(57); UNSET_BIT(6); m += adv1; FALLTHROUGH;
+        case 58: CHECK_FINISHED(58); UNSET_BIT(5); m += adv2; FALLTHROUGH;
+        case 59: CHECK_FINISHED(59); UNSET_BIT(4); m += adv3; FALLTHROUGH;
+        case 60: CHECK_FINISHED(60); UNSET_BIT(3); m += adv4; FALLTHROUGH;
+        case 61: CHECK_FINISHED(61); UNSET_BIT(2); m += adv5; FALLTHROUGH;
+        case 62: CHECK_FINISHED(62); UNSET_BIT(1); m += adv6; FALLTHROUGH;
+        case 63: CHECK_FINISHED(63); UNSET_BIT(0); m += adv7;
+      }
+
+      default: UNREACHABLE;
+    }
   }
 }
 

--- a/src/Sieve.cpp
+++ b/src/Sieve.cpp
@@ -541,7 +541,7 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
         std::size_t is_bit = (sieve_byte >> i) & 1; \
         sieve[m] &= ~(1 << i); \
         uint64_t bucket = m >> counter_log2_dist; \
-        if (bucket != cur_bucket) \
+        if (bucket > cur_bucket) \
         { \
           counter[cur_bucket] -= uint32_t(bucket_delta); \
           count += bucket_delta; \

--- a/src/Sieve.cpp
+++ b/src/Sieve.cpp
@@ -545,8 +545,11 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
     uint64_t bucket_count = 0;
 
     #define CHECK_FINISHED(w) \
-      if (m >= sieve_bytes) \
-        goto finished1_ ## w;
+      if_unlikely(m >= sieve_bytes) \
+      { \
+        primeState.wheel_index = w; \
+        goto finished1; \
+      }
 
     #define UNSET_BIT(i) \
       { \
@@ -668,78 +671,6 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
     #undef UNSET_BIT
     #undef CHECK_FINISHED
 
-    finished1_0:;  primeState.wheel_index = 0;  goto finished1;
-    finished1_1:;  primeState.wheel_index = 1;  goto finished1;
-    finished1_2:;  primeState.wheel_index = 2;  goto finished1;
-    finished1_3:;  primeState.wheel_index = 3;  goto finished1;
-    finished1_4:;  primeState.wheel_index = 4;  goto finished1;
-    finished1_5:;  primeState.wheel_index = 5;  goto finished1;
-    finished1_6:;  primeState.wheel_index = 6;  goto finished1;
-    finished1_7:;  primeState.wheel_index = 7;  goto finished1;
-
-    finished1_8:;  primeState.wheel_index = 8;  goto finished1;
-    finished1_9:;  primeState.wheel_index = 9;  goto finished1;
-    finished1_10:; primeState.wheel_index = 10; goto finished1;
-    finished1_11:; primeState.wheel_index = 11; goto finished1;
-    finished1_12:; primeState.wheel_index = 12; goto finished1;
-    finished1_13:; primeState.wheel_index = 13; goto finished1;
-    finished1_14:; primeState.wheel_index = 14; goto finished1;
-    finished1_15:; primeState.wheel_index = 15; goto finished1;
-
-    finished1_16:; primeState.wheel_index = 16; goto finished1;
-    finished1_17:; primeState.wheel_index = 17; goto finished1;
-    finished1_18:; primeState.wheel_index = 18; goto finished1;
-    finished1_19:; primeState.wheel_index = 19; goto finished1;
-    finished1_20:; primeState.wheel_index = 20; goto finished1;
-    finished1_21:; primeState.wheel_index = 21; goto finished1;
-    finished1_22:; primeState.wheel_index = 22; goto finished1;
-    finished1_23:; primeState.wheel_index = 23; goto finished1;
-
-    finished1_24:; primeState.wheel_index = 24; goto finished1;
-    finished1_25:; primeState.wheel_index = 25; goto finished1;
-    finished1_26:; primeState.wheel_index = 26; goto finished1;
-    finished1_27:; primeState.wheel_index = 27; goto finished1;
-    finished1_28:; primeState.wheel_index = 28; goto finished1;
-    finished1_29:; primeState.wheel_index = 29; goto finished1;
-    finished1_30:; primeState.wheel_index = 30; goto finished1;
-    finished1_31:; primeState.wheel_index = 31; goto finished1;
-
-    finished1_32:; primeState.wheel_index = 32; goto finished1;
-    finished1_33:; primeState.wheel_index = 33; goto finished1;
-    finished1_34:; primeState.wheel_index = 34; goto finished1;
-    finished1_35:; primeState.wheel_index = 35; goto finished1;
-    finished1_36:; primeState.wheel_index = 36; goto finished1;
-    finished1_37:; primeState.wheel_index = 37; goto finished1;
-    finished1_38:; primeState.wheel_index = 38; goto finished1;
-    finished1_39:; primeState.wheel_index = 39; goto finished1;
-
-    finished1_40:; primeState.wheel_index = 40; goto finished1;
-    finished1_41:; primeState.wheel_index = 41; goto finished1;
-    finished1_42:; primeState.wheel_index = 42; goto finished1;
-    finished1_43:; primeState.wheel_index = 43; goto finished1;
-    finished1_44:; primeState.wheel_index = 44; goto finished1;
-    finished1_45:; primeState.wheel_index = 45; goto finished1;
-    finished1_46:; primeState.wheel_index = 46; goto finished1;
-    finished1_47:; primeState.wheel_index = 47; goto finished1;
-
-    finished1_48:; primeState.wheel_index = 48; goto finished1;
-    finished1_49:; primeState.wheel_index = 49; goto finished1;
-    finished1_50:; primeState.wheel_index = 50; goto finished1;
-    finished1_51:; primeState.wheel_index = 51; goto finished1;
-    finished1_52:; primeState.wheel_index = 52; goto finished1;
-    finished1_53:; primeState.wheel_index = 53; goto finished1;
-    finished1_54:; primeState.wheel_index = 54; goto finished1;
-    finished1_55:; primeState.wheel_index = 55; goto finished1;
-
-    finished1_56:; primeState.wheel_index = 56; goto finished1;
-    finished1_57:; primeState.wheel_index = 57; goto finished1;
-    finished1_58:; primeState.wheel_index = 58; goto finished1;
-    finished1_59:; primeState.wheel_index = 59; goto finished1;
-    finished1_60:; primeState.wheel_index = 60; goto finished1;
-    finished1_61:; primeState.wheel_index = 61; goto finished1;
-    finished1_62:; primeState.wheel_index = 62; goto finished1;
-    finished1_63:; primeState.wheel_index = 63; goto finished1;
-
     finished1:;
 
     primeState.multiple = uint32_t(m - sieve_bytes);
@@ -750,8 +681,11 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
   else
   {
     #define CHECK_FINISHED(w) \
-      if (m >= sieve_bytes) \
-        goto finished2_ ## w;
+      if_unlikely(m >= sieve_bytes) \
+      { \
+        primeState.wheel_index = w; \
+        goto finished2; \
+      }
 
     #define UNSET_BIT(i) \
       { \
@@ -863,78 +797,6 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
 
       default: UNREACHABLE;
     }
-
-    finished2_0:;  primeState.wheel_index = 0;  goto finished2;
-    finished2_1:;  primeState.wheel_index = 1;  goto finished2;
-    finished2_2:;  primeState.wheel_index = 2;  goto finished2;
-    finished2_3:;  primeState.wheel_index = 3;  goto finished2;
-    finished2_4:;  primeState.wheel_index = 4;  goto finished2;
-    finished2_5:;  primeState.wheel_index = 5;  goto finished2;
-    finished2_6:;  primeState.wheel_index = 6;  goto finished2;
-    finished2_7:;  primeState.wheel_index = 7;  goto finished2;
-
-    finished2_8:;  primeState.wheel_index = 8;  goto finished2;
-    finished2_9:;  primeState.wheel_index = 9;  goto finished2;
-    finished2_10:; primeState.wheel_index = 10; goto finished2;
-    finished2_11:; primeState.wheel_index = 11; goto finished2;
-    finished2_12:; primeState.wheel_index = 12; goto finished2;
-    finished2_13:; primeState.wheel_index = 13; goto finished2;
-    finished2_14:; primeState.wheel_index = 14; goto finished2;
-    finished2_15:; primeState.wheel_index = 15; goto finished2;
-
-    finished2_16:; primeState.wheel_index = 16; goto finished2;
-    finished2_17:; primeState.wheel_index = 17; goto finished2;
-    finished2_18:; primeState.wheel_index = 18; goto finished2;
-    finished2_19:; primeState.wheel_index = 19; goto finished2;
-    finished2_20:; primeState.wheel_index = 20; goto finished2;
-    finished2_21:; primeState.wheel_index = 21; goto finished2;
-    finished2_22:; primeState.wheel_index = 22; goto finished2;
-    finished2_23:; primeState.wheel_index = 23; goto finished2;
-
-    finished2_24:; primeState.wheel_index = 24; goto finished2;
-    finished2_25:; primeState.wheel_index = 25; goto finished2;
-    finished2_26:; primeState.wheel_index = 26; goto finished2;
-    finished2_27:; primeState.wheel_index = 27; goto finished2;
-    finished2_28:; primeState.wheel_index = 28; goto finished2;
-    finished2_29:; primeState.wheel_index = 29; goto finished2;
-    finished2_30:; primeState.wheel_index = 30; goto finished2;
-    finished2_31:; primeState.wheel_index = 31; goto finished2;
-
-    finished2_32:; primeState.wheel_index = 32; goto finished2;
-    finished2_33:; primeState.wheel_index = 33; goto finished2;
-    finished2_34:; primeState.wheel_index = 34; goto finished2;
-    finished2_35:; primeState.wheel_index = 35; goto finished2;
-    finished2_36:; primeState.wheel_index = 36; goto finished2;
-    finished2_37:; primeState.wheel_index = 37; goto finished2;
-    finished2_38:; primeState.wheel_index = 38; goto finished2;
-    finished2_39:; primeState.wheel_index = 39; goto finished2;
-
-    finished2_40:; primeState.wheel_index = 40; goto finished2;
-    finished2_41:; primeState.wheel_index = 41; goto finished2;
-    finished2_42:; primeState.wheel_index = 42; goto finished2;
-    finished2_43:; primeState.wheel_index = 43; goto finished2;
-    finished2_44:; primeState.wheel_index = 44; goto finished2;
-    finished2_45:; primeState.wheel_index = 45; goto finished2;
-    finished2_46:; primeState.wheel_index = 46; goto finished2;
-    finished2_47:; primeState.wheel_index = 47; goto finished2;
-
-    finished2_48:; primeState.wheel_index = 48; goto finished2;
-    finished2_49:; primeState.wheel_index = 49; goto finished2;
-    finished2_50:; primeState.wheel_index = 50; goto finished2;
-    finished2_51:; primeState.wheel_index = 51; goto finished2;
-    finished2_52:; primeState.wheel_index = 52; goto finished2;
-    finished2_53:; primeState.wheel_index = 53; goto finished2;
-    finished2_54:; primeState.wheel_index = 54; goto finished2;
-    finished2_55:; primeState.wheel_index = 55; goto finished2;
-
-    finished2_56:; primeState.wheel_index = 56; goto finished2;
-    finished2_57:; primeState.wheel_index = 57; goto finished2;
-    finished2_58:; primeState.wheel_index = 58; goto finished2;
-    finished2_59:; primeState.wheel_index = 59; goto finished2;
-    finished2_60:; primeState.wheel_index = 60; goto finished2;
-    finished2_61:; primeState.wheel_index = 61; goto finished2;
-    finished2_62:; primeState.wheel_index = 62; goto finished2;
-    finished2_63:; primeState.wheel_index = 63; goto finished2;
 
     finished2:;
 

--- a/src/Sieve.cpp
+++ b/src/Sieve.cpp
@@ -519,7 +519,7 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
   uint64_t count = 0;
   uint32_t* counter = &counter_[0];
   uint64_t counter_log2_dist = counter_.log2_dist;
-  bool is_small_prime = (prime <= (4ull << counter_log2_dist));
+  bool is_small_prime = (prime <= (2ull << counter_log2_dist));
 
   prime /= 30;
   uint64_t adv0 = prime * 6 + wheel_corr[g][0];

--- a/src/Sieve.cpp
+++ b/src/Sieve.cpp
@@ -505,6 +505,12 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
   uint64_t count = 0;
   uint32_t* counter = &counter_[0];
   uint64_t counter_log2_dist = counter_.log2_dist;
+
+  // The factor 2 here is a tuning parameter that selects
+  // which primes use the algorithm optimized for small primes.
+  // It was fastest (or nearly so) on every CPU I benchmarked:
+  // best on Intel Arrow Lake and AMD Zen5, while the Apple M2
+  // was 2% faster with a factor of 4.
   bool is_small_prime = (prime <= (2ull << counter_log2_dist));
 
   PrimeState& primeState = primeState_[i];

--- a/src/Sieve.cpp
+++ b/src/Sieve.cpp
@@ -544,7 +544,7 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
     uint64_t bucket_count = 0;
 
     #define CHECK_FINISHED(w) \
-      if_unlikely(m >= sieve_bytes) \
+      if (m >= sieve_bytes) \
       { \
         primeState.wheel_index = w; \
         goto finished1; \
@@ -682,7 +682,7 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
   else
   {
     #define CHECK_FINISHED(w) \
-      if_unlikely(m >= sieve_bytes) \
+      if (m >= sieve_bytes) \
       { \
         primeState.wheel_index = w; \
         goto finished2; \

--- a/src/Sieve.cpp
+++ b/src/Sieve.cpp
@@ -660,9 +660,9 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
 
     counter[cur_bucket] -= uint32_t(bucket_count);
     primeState.multiple = uint32_t(m - sieve_bytes);
-    many_hits_per_bucket_ = (count >= many_hits_threshold_);
     count += bucket_count;
     total_count_ -= count;
+    many_hits_per_bucket_ = (count >= many_hits_threshold_);
   }
   else
   {

--- a/src/Sieve.cpp
+++ b/src/Sieve.cpp
@@ -112,8 +112,8 @@ void Sieve::allocate_counter(uint64_t low)
   // Hence the max(counter value) = 2^18.
   ASSERT(bytes * 8 <= pstd::numeric_limits<uint32_t>::max());
   uint64_t sieve_bytes = sieve_.size() * 8;
-  uint64_t counter_size = ceil_div(sieve_bytes, bytes);
-  counter_.counter.resize(counter_size);
+  counter_size_ = ceil_div(sieve_bytes, bytes);
+  counter_.counter.resize(counter_size_);
   counter_.dist = bytes * 30;
   counter_.log2_dist = ilog2(bytes);
 }
@@ -502,24 +502,17 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
   if (i >= primeState_.size())
     add(prime, i);
 
+  uint64_t count = 0;
+  uint32_t* counter = &counter_[0];
+  uint64_t counter_log2_dist = counter_.log2_dist;
+  bool is_small_prime = (prime <= (2ull << counter_log2_dist));
+
   PrimeState& primeState = primeState_[i];
   uint64_t wheel_index = primeState.wheel_index;
   uint64_t g = wheel_index / 8;
   uint64_t m = primeState.multiple;
   uint8_t* sieve = (uint8_t*) &sieve_[0];
   uint64_t sieve_bytes = sieve_.size() * 8;
-
-  if (m >= sieve_bytes)
-  {
-    uint32_t m32 = uint32_t(m - sieve_bytes);
-    primeState.multiple = m32;
-    return;
-  }
-
-  uint64_t count = 0;
-  uint32_t* counter = &counter_[0];
-  uint64_t counter_log2_dist = counter_.log2_dist;
-  bool is_small_prime = (prime <= (2ull << counter_log2_dist));
 
   prime /= 30;
   uint64_t adv0 = prime * 6 + wheel_corr[g][0];
@@ -673,8 +666,10 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
 
     finished1:;
 
+    if (cur_bucket < counter_size_)
+      counter[cur_bucket] -= uint32_t(bucket_count);
+
     primeState.multiple = uint32_t(m - sieve_bytes);
-    counter[cur_bucket] -= uint32_t(bucket_count);
     count += bucket_count;
     total_count_ -= count;
   }

--- a/src/Sieve.cpp
+++ b/src/Sieve.cpp
@@ -538,10 +538,10 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
     uint64_t bucket_count = 0;
 
     #define CHECK_FINISHED(w) \
-      if_unlikely(m >= sieve_bytes) \
+      if (m >= sieve_bytes) \
       { \
         primeState.wheel_index = w; \
-        goto finished; \
+        goto finished1; \
       }
 
     #define UNSET_BIT(i) \
@@ -664,7 +664,7 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
     #undef UNSET_BIT
     #undef CHECK_FINISHED
 
-    finished:;
+    finished1:;
 
     primeState.multiple = uint32_t(m - sieve_bytes);
     counter[cur_bucket] -= uint32_t(bucket_count);
@@ -675,12 +675,10 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
   else
   {
     #define CHECK_FINISHED(w) \
-      if_unlikely(m >= sieve_bytes) \
+      if (m >= sieve_bytes) \
       { \
         primeState.wheel_index = w; \
-        primeState.multiple = uint32_t(m - sieve_bytes); \
-        total_count_ -= count; \
-        return; \
+        goto finished2; \
       }
 
     #define UNSET_BIT(i) \
@@ -793,6 +791,12 @@ void Sieve::cross_off_count(uint64_t prime, uint64_t i)
 
       default: UNREACHABLE;
     }
+
+    finished2:;
+
+    uint32_t m32 = uint32_t(m - sieve_bytes);
+    primeState.multiple = m32;
+    total_count_ -= count;
   }
 }
 

--- a/src/Sieve.hpp
+++ b/src/Sieve.hpp
@@ -150,8 +150,6 @@ private:
   uint64_t prev_stop_ = 0;
   uint64_t count_ = 0;
   uint64_t total_count_ = 0;
-  uint64_t many_hits_threshold_ = 0;
-  bool many_hits_per_bucket_ = true;
   Vector<uint64_t> sieve_;
   Vector<PrimeState> primeState_;
   Counter counter_;

--- a/src/Sieve.hpp
+++ b/src/Sieve.hpp
@@ -150,6 +150,7 @@ private:
   uint64_t prev_stop_ = 0;
   uint64_t count_ = 0;
   uint64_t total_count_ = 0;
+  uint64_t many_hits_threshold_ = 0;
   bool many_hits_per_bucket_ = true;
   Vector<uint64_t> sieve_;
   Vector<PrimeState> primeState_;

--- a/src/Sieve.hpp
+++ b/src/Sieve.hpp
@@ -150,6 +150,7 @@ private:
   uint64_t prev_stop_ = 0;
   uint64_t count_ = 0;
   uint64_t total_count_ = 0;
+  uint64_t counter_size_ = 0;
   Vector<uint64_t> sieve_;
   Vector<PrimeState> primeState_;
   Counter counter_;

--- a/src/Sieve.hpp
+++ b/src/Sieve.hpp
@@ -150,6 +150,7 @@ private:
   uint64_t prev_stop_ = 0;
   uint64_t count_ = 0;
   uint64_t total_count_ = 0;
+  bool many_hits_per_bucket_ = true;
   Vector<uint64_t> sieve_;
   Vector<PrimeState> primeState_;
   Counter counter_;


### PR DESCRIPTION
A small sieving prime hits the same counter array element many times in a row. Decrementing `counter[c]` on each hit
is a read-modify-write to the same address, so on out-of-order CPUs the hits serialize on store-to-load forwarding latency. Hence, for such small primes we use an alternative algorithm that avoids this by accumulating the count in a register, subtracting from `counter[c]` only once when the counter index `c` increases.

This new sieving algorithm improves the performance of the D algorithm by up to 45% on Apple Silicon CPUs and by up to 10% on AMD Zen5 CPUs.