### PR TITLE
Improved AC algorithm using Gourdon's inversion equality

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,8 @@
-Changes in primecount-8.7, 2026-07-23
+Changes in primecount-8.7, 2026-07-25
 
-* AC.cpp: Simplify clustered easy leaves algorithm using Gourdon's inversion equality.
+* AC.cpp: Improve clustered easy leaves algorithm using Gourdon's inversion equality.
+* SegmentedPiTable.hpp: Switch return types to uint64_t for new AC.cpp code.
+* util.cpp: Tune alpha_z=1.2 for new AC algorithm.
 
 Changes in primecount-8.6, 2026-07-15
 

--- a/src/gourdon/AC.cpp
+++ b/src/gourdon/AC.cpp
@@ -190,13 +190,10 @@ T C2(T xlow,
   uint64_t sqrt_xp = (uint64_t) isqrt(xp);
   uint64_t min_clustered = in_between(min_m, sqrt_xp, max_m);
   uint64_t pi_min_clustered = pi[min_clustered];
-  XP min_clustered128 =
-      max3(xp / (prime * prime), (XP) prime, (XP) sqrt_xp);
-  uint64_t min_clustered_global =
-      (uint64_t) min(min_clustered128, (XP) y);
+  XP min_clustered128 = max3(xp / (prime * prime), prime, sqrt_xp);
+  uint64_t min_clustered_global = min(min_clustered128, y);
   uint64_t max_clustered_global = max_y_prime;
-  bool has_clustered =
-      max_clustered_global > min_clustered_global;
+  bool has_clustered = max_clustered_global > min_clustered_global;
 
   // For fixed p, ]min_clustered_global, max_clustered_global] is
   // the complete clustered interval. Emit its boundary correction
@@ -208,14 +205,11 @@ T C2(T xlow,
   {
     if (has_clustered && i == pi_y)
     {
-      uint64_t q_lo =
-          fast_div64(xp, max_clustered_global);
-      uint64_t q_hi =
-          fast_div64(xp, min_clustered_global + 1);
+      uint64_t q_lo = fast_div64(xp, max_clustered_global);
+      uint64_t q_hi = fast_div64(xp, min_clustered_global + 1);
       uint64_t pi_q_lo = pi[q_lo];
       uint64_t pi_q_hi = pi[q_hi];
-      uint64_t pi_min_clustered_global =
-          pi[min_clustered_global];
+      uint64_t pi_min_clustered_global = pi[min_clustered_global];
 
       sum += T(pi_q_lo) * pi_y
            - T(pi_q_hi) * pi_min_clustered_global;
@@ -672,13 +666,10 @@ T C2_64(T xlow,
   uint64_t sqrt_xp = isqrt(xp);
   uint64_t min_clustered = in_between(min_m, sqrt_xp, max_m);
   uint64_t pi_min_clustered = pi[min_clustered];
-  uint64_t min_clustered128 =
-      max3(xp / (prime * prime), prime, sqrt_xp);
-  uint64_t min_clustered_global =
-      min(min_clustered128, y);
+  uint64_t min_clustered128 = max3(xp / (prime * prime), prime, sqrt_xp);
+  uint64_t min_clustered_global = min(min_clustered128, y);
   uint64_t max_clustered_global = max_y_prime;
-  bool has_clustered =
-      max_clustered_global > min_clustered_global;
+  bool has_clustered = max_clustered_global > min_clustered_global;
 
   // For fixed p, ]min_clustered_global, max_clustered_global] is
   // the complete clustered interval. Emit its boundary correction
@@ -690,14 +681,11 @@ T C2_64(T xlow,
   {
     if (has_clustered && i == pi_y)
     {
-      uint64_t q_lo =
-          fast_div64(xp, max_clustered_global);
-      uint64_t q_hi =
-          fast_div64(xp, min_clustered_global + 1);
+      uint64_t q_lo = fast_div64(xp, max_clustered_global);
+      uint64_t q_hi = fast_div64(xp, min_clustered_global + 1);
       uint64_t pi_q_lo = pi[q_lo];
       uint64_t pi_q_hi = pi[q_hi];
-      uint64_t pi_min_clustered_global =
-          pi[min_clustered_global];
+      uint64_t pi_min_clustered_global = pi[min_clustered_global];
 
       sum += T(pi_q_lo) * pi_y
            - T(pi_q_hi) * pi_min_clustered_global;
@@ -841,13 +829,10 @@ T C2_128(T xlow,
   uint64_t sqrt_xp = (uint64_t) isqrt(xp);
   uint64_t min_clustered = in_between(min_m, sqrt_xp, max_m);
   uint64_t pi_min_clustered = pi[min_clustered];
-  T min_clustered128 =
-      max3(xp / (prime * prime), (T) prime, (T) sqrt_xp);
-  uint64_t min_clustered_global =
-      (uint64_t) min(min_clustered128, (T) y);
+  T min_clustered128 = max3(xp / (prime * prime), prime, sqrt_xp);
+  uint64_t min_clustered_global = min(min_clustered128, y);
   uint64_t max_clustered_global = max_y_prime;
-  bool has_clustered =
-      max_clustered_global > min_clustered_global;
+  bool has_clustered = max_clustered_global > min_clustered_global;
 
   // For fixed p, ]min_clustered_global, max_clustered_global] is
   // the complete clustered interval. Emit its boundary correction
@@ -859,14 +844,11 @@ T C2_128(T xlow,
   {
     if (has_clustered && i == pi_y)
     {
-      uint64_t q_lo =
-          fast_div64(xp, max_clustered_global);
-      uint64_t q_hi =
-          fast_div64(xp, min_clustered_global + 1);
+      uint64_t q_lo = fast_div64(xp, max_clustered_global);
+      uint64_t q_hi = fast_div64(xp, min_clustered_global + 1);
       uint64_t pi_q_lo = pi[q_lo];
       uint64_t pi_q_hi = pi[q_hi];
-      uint64_t pi_min_clustered_global =
-          pi[min_clustered_global];
+      uint64_t pi_min_clustered_global = pi[min_clustered_global];
 
       sum += T(pi_q_lo) * pi_y
            - T(pi_q_hi) * pi_min_clustered_global;

--- a/src/gourdon/AC.cpp
+++ b/src/gourdon/AC.cpp
@@ -206,7 +206,7 @@ T C2(T xlow,
     sum -= T(b - 2) * (pi_y - pi_min_clustered_global);
   }
 
-  // Reflected leaves occupy the contiguous ]pi_conj_lo, pi_conj_hi].
+  // Reflected leaves occupy the contiguous ]pi_conj_lo, pi_conj_hi]
   if (min_clustered_global < max_clustered_global &&
       segmentedPi.low() < max_clustered_global &&
       segmentedPi.high() > min_clustered_global + 1)
@@ -218,21 +218,21 @@ T C2(T xlow,
     pi_conj_hi = max(pi_conj_hi, pi_conj_lo);
   }
 
-  // Sparse leaves below the reflected sub-range.
+  // Sparse leaves below the reflected sub-range
   for (; i <= pi_conj_lo; i++)
   {
     uint64_t xpq = fast_div64(xp, primes[i]);
     sum += segmentedPi[xpq] - b + 2;
   }
 
-  // Reflected leaves: counted once as a sparse leaf, once as a conjugate.
+  // Reflected leaves: counted once as a sparse leaf, once as a conjugate
   for (; i <= pi_conj_hi; i++)
   {
     uint64_t xpq = fast_div64(xp, primes[i]);
     sum += segmentedPi[xpq] * 2 - b + 2;
   }
 
-  // Sparse leaves above the reflected sub-range.
+  // Sparse leaves above the reflected sub-range
   for (; i <= pi_min_clustered; i++)
   {
     uint64_t xpq = fast_div64(xp, primes[i]);
@@ -601,7 +601,7 @@ T C2_64(T xlow,
     sum -= T(b - 2) * (pi_y - pi_min_clustered_global);
   }
 
-  // Reflected leaves occupy the contiguous ]pi_conj_lo, pi_conj_hi].
+  // Reflected leaves occupy the contiguous ]pi_conj_lo, pi_conj_hi]
   if (min_clustered_global < max_clustered_global &&
       segmentedPi.low() < max_clustered_global &&
       segmentedPi.high() > min_clustered_global + 1)
@@ -613,21 +613,21 @@ T C2_64(T xlow,
     pi_conj_hi = max(pi_conj_hi, pi_conj_lo);
   }
 
-  // Sparse leaves below the reflected sub-range.
+  // Sparse leaves below the reflected sub-range
   for (; i <= pi_conj_lo; i++)
   {
     uint64_t xpq = xp / primes[i];
     sum += segmentedPi[xpq] - b + 2;
   }
 
-  // Reflected leaves: counted once as a sparse leaf, once as a conjugate.
+  // Reflected leaves: counted once as a sparse leaf, once as a conjugate
   for (; i <= pi_conj_hi; i++)
   {
     uint64_t xpq = xp / primes[i];
     sum += segmentedPi[xpq] * 2 - b + 2;
   }
 
-  // Sparse leaves above the reflected sub-range.
+  // Sparse leaves above the reflected sub-range
   for (; i <= pi_min_clustered; i++)
   {
     uint64_t xpq = xp / primes[i];
@@ -683,7 +683,7 @@ T C2_128(T xlow,
     sum -= T(b - 2) * (pi_y - pi_min_clustered_global);
   }
 
-  // Reflected leaves occupy the contiguous ]pi_conj_lo, pi_conj_hi].
+  // Reflected leaves occupy the contiguous ]pi_conj_lo, pi_conj_hi]
   if (min_clustered_global < max_clustered_global &&
       segmentedPi.low() < max_clustered_global &&
       segmentedPi.high() > min_clustered_global + 1)
@@ -695,21 +695,21 @@ T C2_128(T xlow,
     pi_conj_hi = max(pi_conj_hi, pi_conj_lo);
   }
 
-  // Sparse leaves below the reflected sub-range.
+  // Sparse leaves below the reflected sub-range
   for (; i <= pi_conj_lo; i++)
   {
     uint64_t xpq = fast_div64(xp, primes[i]);
     sum += segmentedPi[xpq] - b + 2;
   }
 
-  // Reflected leaves: counted once as a sparse leaf, once as a conjugate.
+  // Reflected leaves: counted once as a sparse leaf, once as a conjugate
   for (; i <= pi_conj_hi; i++)
   {
     uint64_t xpq = fast_div64(xp, primes[i]);
     sum += segmentedPi[xpq] * 2 - b + 2;
   }
 
-  // Sparse leaves above the reflected sub-range.
+  // Sparse leaves above the reflected sub-range
   for (; i <= pi_min_clustered; i++)
   {
     uint64_t xpq = fast_div64(xp, primes[i]);

--- a/src/gourdon/AC.cpp
+++ b/src/gourdon/AC.cpp
@@ -173,6 +173,8 @@ T C2(T xlow,
      XP xp,
      uint64_t y,
      uint64_t b,
+     uint64_t pi_y,
+     uint64_t max_y_prime,
      const Primes& primes,
      const PiTable& pi,
      const SegmentedPiTable& segmentedPi)
@@ -185,79 +187,143 @@ T C2(T xlow,
   uint64_t min_m = min(min_m128, max_m);
   uint64_t i = pi[max_m];
   uint64_t pi_min_m = pi[min_m];
-  uint64_t min_clustered = (uint64_t) isqrt(xp);
-  min_clustered = in_between(min_m, min_clustered, max_m);
+  uint64_t sqrt_xp = (uint64_t) isqrt(xp);
+  uint64_t min_clustered = in_between(min_m, sqrt_xp, max_m);
   uint64_t pi_min_clustered = pi[min_clustered];
+  XP min_clustered128 =
+      max3(xp / (prime * prime), (XP) prime, (XP) sqrt_xp);
+  uint64_t min_clustered_global =
+      (uint64_t) min(min_clustered128, (XP) y);
+  uint64_t max_clustered_global = max_y_prime;
+  bool has_clustered =
+      max_clustered_global > min_clustered_global;
 
-  // Clustered easy leaves: q in ]min_clustered, max_m], where
-  // x / (p*q) < √(x / p). Gourdon's inversion equality turns this
-  // band into a sum over the conjugate range (t = x / p):
-  //
-  //   sum_{min_clustered < q <= max_m} pi(t / q) =
-  //     pi(q_lo) * pi(max_m) - pi(q_hi) * pi(min_clustered)
-  //     + sum_{q_lo < q <= q_hi} pi(t / q)
-  //
-  // The conjugate arguments t / q are <= y, hence they are read
-  // from the pi table instead of segmentedPi.
+  // For fixed p, ]min_clustered_global, max_clustered_global] is
+  // the complete clustered interval. Emit its boundary correction
+  // once, in the unique segment containing max_clustered_global.
+  // The reflected terms are accumulated by the sparse loops below,
+  // possibly in other segments. All contributions use the existing
+  // OpenMP reduction, hence no synchronization is needed.
   if (i > pi_min_clustered)
   {
-    uint64_t q_lo = fast_div64(xp, max_m);
-    uint64_t q_hi = fast_div64(xp, min_clustered + 1);
-    uint64_t pi_q_lo = pi[q_lo];
-    uint64_t pi_q_hi = pi[q_hi];
-    uint64_t j = pi_q_hi;
-
-    T conj_sum = 0;
-
-    // Unroll loop to increase instruction level parallelism
-    for (; j > pi_q_lo + 3; j -= 4)
+    if (has_clustered && i == pi_y)
     {
-      uint64_t xpq0 = fast_div64(xp, primes[j]);
-      uint64_t xpq1 = fast_div64(xp, primes[j-1]);
-      uint64_t xpq2 = fast_div64(xp, primes[j-2]);
-      uint64_t xpq3 = fast_div64(xp, primes[j-3]);
+      uint64_t q_lo =
+          fast_div64(xp, max_clustered_global);
+      uint64_t q_hi =
+          fast_div64(xp, min_clustered_global + 1);
+      uint64_t pi_q_lo = pi[q_lo];
+      uint64_t pi_q_hi = pi[q_hi];
+      uint64_t pi_min_clustered_global =
+          pi[min_clustered_global];
 
-      conj_sum += pi[xpq0] +
-                  pi[xpq1] +
-                  pi[xpq2] +
-                  pi[xpq3];
+      sum += T(pi_q_lo) * pi_y
+           - T(pi_q_hi) * pi_min_clustered_global;
+      sum -= T(b - 2) *
+             (pi_y - pi_min_clustered_global);
     }
-
-    for (; j > pi_q_lo; j--)
-    {
-      uint64_t xpq = fast_div64(xp, primes[j]);
-      conj_sum += pi[xpq];
-    }
-
-    sum += T(pi_q_lo) * i - T(pi_q_hi) * pi_min_clustered + conj_sum;
-    sum -= T(b - 2) * (i - pi_min_clustered);
 
     i = pi_min_clustered;
   }
 
-  // Unroll loop to increase instruction level parallelism
-  for (; i > pi_min_m + 3; i -= 4)
-  {
-    uint64_t xpq0 = fast_div64(xp, primes[i]);
-    uint64_t xpq1 = fast_div64(xp, primes[i-1]);
-    uint64_t xpq2 = fast_div64(xp, primes[i-2]);
-    uint64_t xpq3 = fast_div64(xp, primes[i-3]);
+  uint64_t segment_low = (uint64_t) segmentedPi.low();
+  uint64_t segment_high = (uint64_t) segmentedPi.high();
+  bool all_conjugate =
+      has_clustered &&
+      segment_low > min_clustered_global &&
+      segment_high <= max_clustered_global;
+  bool overlaps_conjugate =
+      has_clustered &&
+      segment_high > min_clustered_global + 1 &&
+      segment_low < max_clustered_global;
 
-    sum += (segmentedPi[xpq0] - b + 2) +
-           (segmentedPi[xpq1] - b + 2) +
-           (segmentedPi[xpq2] - b + 2) +
-           (segmentedPi[xpq3] - b + 2);
+  if (all_conjugate)
+  {
+    // Every sparse leaf in this segment is also reflected.
+    for (; i > pi_min_m + 3; i -= 4)
+    {
+      uint64_t xpq0 = fast_div64(xp, primes[i]);
+      uint64_t xpq1 = fast_div64(xp, primes[i-1]);
+      uint64_t xpq2 = fast_div64(xp, primes[i-2]);
+      uint64_t xpq3 = fast_div64(xp, primes[i-3]);
+
+      sum += (segmentedPi[xpq0] * 2 - b + 2) +
+             (segmentedPi[xpq1] * 2 - b + 2) +
+             (segmentedPi[xpq2] * 2 - b + 2) +
+             (segmentedPi[xpq3] * 2 - b + 2);
+    }
+
+    for (; i > pi_min_m; i--)
+    {
+      uint64_t xpq = fast_div64(xp, primes[i]);
+      sum += segmentedPi[xpq] * 2 - b + 2;
+    }
   }
-
-  // Find all sparse easy leaves where
-  // successive leaves are different.
-  // pq = primes[b] * primes[i]
-  // Which satisfy: low <= x / pq < high && q <= y && pq > z
-  // where phi(x / pq, b - 1) = pi(x / pq) - b + 2
-  for (; i > pi_min_m; i--)
+  else if (!overlaps_conjugate)
   {
-    uint64_t xpq = fast_div64(xp, primes[i]);
-    sum += segmentedPi[xpq] - b + 2;
+    // This segment has no reflected terms.
+    for (; i > pi_min_m + 3; i -= 4)
+    {
+      uint64_t xpq0 = fast_div64(xp, primes[i]);
+      uint64_t xpq1 = fast_div64(xp, primes[i-1]);
+      uint64_t xpq2 = fast_div64(xp, primes[i-2]);
+      uint64_t xpq3 = fast_div64(xp, primes[i-3]);
+
+      sum += (segmentedPi[xpq0] - b + 2) +
+             (segmentedPi[xpq1] - b + 2) +
+             (segmentedPi[xpq2] - b + 2) +
+             (segmentedPi[xpq3] - b + 2);
+    }
+
+    for (; i > pi_min_m; i--)
+    {
+      uint64_t xpq = fast_div64(xp, primes[i]);
+      sum += segmentedPi[xpq] - b + 2;
+    }
+  }
+  else
+  {
+    // Only segments crossing a clustered endpoint need range tests.
+    for (; i > pi_min_m + 3; i -= 4)
+    {
+      uint64_t xpq0 = fast_div64(xp, primes[i]);
+      uint64_t xpq1 = fast_div64(xp, primes[i-1]);
+      uint64_t xpq2 = fast_div64(xp, primes[i-2]);
+      uint64_t xpq3 = fast_div64(xp, primes[i-3]);
+      T pix0 = segmentedPi[xpq0];
+      T pix1 = segmentedPi[xpq1];
+      T pix2 = segmentedPi[xpq2];
+      T pix3 = segmentedPi[xpq3];
+
+      sum += (pix0 - b + 2) +
+             (pix1 - b + 2) +
+             (pix2 - b + 2) +
+             (pix3 - b + 2);
+
+      if (min_clustered_global < xpq0 &&
+          xpq0 < max_clustered_global)
+        sum += pix0;
+      if (min_clustered_global < xpq1 &&
+          xpq1 < max_clustered_global)
+        sum += pix1;
+      if (min_clustered_global < xpq2 &&
+          xpq2 < max_clustered_global)
+        sum += pix2;
+      if (min_clustered_global < xpq3 &&
+          xpq3 < max_clustered_global)
+        sum += pix3;
+    }
+
+    for (; i > pi_min_m; i--)
+    {
+      uint64_t xpq = fast_div64(xp, primes[i]);
+      T pix = segmentedPi[xpq];
+      sum += pix - b + 2;
+
+      if (min_clustered_global < xpq &&
+          xpq < max_clustered_global)
+        sum += pix;
+    }
   }
 
   return sum;
@@ -296,7 +362,8 @@ T AC_OpenMP(T x,
   // is fairly large and does not fit into the CPU's cache.
   PiTable pi(max(z, max_a_prime), threads);
 
-  int64_t pi_y = pi[y];
+  uint64_t pi_y = pi[y];
+  uint64_t max_y_prime = pi_y ? primes[pi_y] : 0;
   int64_t pi_sqrtz = pi[isqrt(z)];
   int64_t pi_root3_xy = pi[iroot<3>(xy)];
   int64_t pi_root3_xz = pi[iroot<3>(xz)];
@@ -382,9 +449,9 @@ T AC_OpenMP(T x,
           T xp = x / primes[b];
 
           if (xp <= pstd::numeric_limits<uint64_t>::max())
-            sum += C2(xlow, xhigh, uint64_t(xp), y, b, primes, pi, segmentedPi);
+            sum += C2(xlow, xhigh, uint64_t(xp), y, b, pi_y, max_y_prime, primes, pi, segmentedPi);
           else
-            sum += C2(xlow, xhigh, xp, y, b, primes, pi, segmentedPi);
+            sum += C2(xlow, xhigh, xp, y, b, pi_y, max_y_prime, primes, pi, segmentedPi);
         }
 
         // A formula: pi[x_star] < b <= pi[x13]
@@ -588,6 +655,8 @@ T C2_64(T xlow,
         uint64_t xp,
         uint64_t y,
         uint64_t b,
+        uint64_t pi_y,
+        uint64_t max_y_prime,
         uint64_t prime,
         const LibdividePrimes& primes,
         const PiTable& pi,
@@ -600,79 +669,143 @@ T C2_64(T xlow,
   uint64_t min_m = min(min_m128, max_m);
   uint64_t i = pi[max_m];
   uint64_t pi_min_m = pi[min_m];
-  uint64_t min_clustered = isqrt(xp);
-  min_clustered = in_between(min_m, min_clustered, max_m);
+  uint64_t sqrt_xp = isqrt(xp);
+  uint64_t min_clustered = in_between(min_m, sqrt_xp, max_m);
   uint64_t pi_min_clustered = pi[min_clustered];
+  uint64_t min_clustered128 =
+      max3(xp / (prime * prime), prime, sqrt_xp);
+  uint64_t min_clustered_global =
+      min(min_clustered128, y);
+  uint64_t max_clustered_global = max_y_prime;
+  bool has_clustered =
+      max_clustered_global > min_clustered_global;
 
-  // Clustered easy leaves: q in ]min_clustered, max_m], where
-  // x / (p*q) < √(x / p). Gourdon's inversion equality turns this
-  // band into a sum over the conjugate range (t = x / p):
-  //
-  //   sum_{min_clustered < q <= max_m} pi(t / q) =
-  //     pi(q_lo) * pi(max_m) - pi(q_hi) * pi(min_clustered)
-  //     + sum_{q_lo < q <= q_hi} pi(t / q)
-  //
-  // The conjugate arguments t / q are <= y, hence they are read
-  // from the pi table instead of segmentedPi.
+  // For fixed p, ]min_clustered_global, max_clustered_global] is
+  // the complete clustered interval. Emit its boundary correction
+  // once, in the unique segment containing max_clustered_global.
+  // The reflected terms are accumulated by the sparse loops below,
+  // possibly in other segments. All contributions use the existing
+  // OpenMP reduction, hence no synchronization is needed.
   if (i > pi_min_clustered)
   {
-    uint64_t q_lo = fast_div64(xp, max_m);
-    uint64_t q_hi = fast_div64(xp, min_clustered + 1);
-    uint64_t pi_q_lo = pi[q_lo];
-    uint64_t pi_q_hi = pi[q_hi];
-    uint64_t j = pi_q_hi;
-
-    T conj_sum = 0;
-
-    // Unroll loop to increase instruction level parallelism
-    for (; j > pi_q_lo + 3; j -= 4)
+    if (has_clustered && i == pi_y)
     {
-      uint64_t xpq0 = xp / primes[j];
-      uint64_t xpq1 = xp / primes[j-1];
-      uint64_t xpq2 = xp / primes[j-2];
-      uint64_t xpq3 = xp / primes[j-3];
+      uint64_t q_lo =
+          fast_div64(xp, max_clustered_global);
+      uint64_t q_hi =
+          fast_div64(xp, min_clustered_global + 1);
+      uint64_t pi_q_lo = pi[q_lo];
+      uint64_t pi_q_hi = pi[q_hi];
+      uint64_t pi_min_clustered_global =
+          pi[min_clustered_global];
 
-      conj_sum += pi[xpq0] +
-                  pi[xpq1] +
-                  pi[xpq2] +
-                  pi[xpq3];
+      sum += T(pi_q_lo) * pi_y
+           - T(pi_q_hi) * pi_min_clustered_global;
+      sum -= T(b - 2) *
+             (pi_y - pi_min_clustered_global);
     }
-
-    for (; j > pi_q_lo; j--)
-    {
-      uint64_t xpq = xp / primes[j];
-      conj_sum += pi[xpq];
-    }
-
-    sum += T(pi_q_lo) * i - T(pi_q_hi) * pi_min_clustered + conj_sum;
-    sum -= T(b - 2) * (i - pi_min_clustered);
 
     i = pi_min_clustered;
   }
 
-  // Unroll loop to increase instruction level parallelism
-  for (; i > pi_min_m + 3; i -= 4)
-  {
-    uint64_t xpq0 = xp / primes[i];
-    uint64_t xpq1 = xp / primes[i-1];
-    uint64_t xpq2 = xp / primes[i-2];
-    uint64_t xpq3 = xp / primes[i-3];
+  uint64_t segment_low = (uint64_t) segmentedPi.low();
+  uint64_t segment_high = (uint64_t) segmentedPi.high();
+  bool all_conjugate =
+      has_clustered &&
+      segment_low > min_clustered_global &&
+      segment_high <= max_clustered_global;
+  bool overlaps_conjugate =
+      has_clustered &&
+      segment_high > min_clustered_global + 1 &&
+      segment_low < max_clustered_global;
 
-    sum += (segmentedPi[xpq0] - b + 2) +
-           (segmentedPi[xpq1] - b + 2) +
-           (segmentedPi[xpq2] - b + 2) +
-           (segmentedPi[xpq3] - b + 2);
+  if (all_conjugate)
+  {
+    // Every sparse leaf in this segment is also reflected.
+    for (; i > pi_min_m + 3; i -= 4)
+    {
+      uint64_t xpq0 = xp / primes[i];
+      uint64_t xpq1 = xp / primes[i-1];
+      uint64_t xpq2 = xp / primes[i-2];
+      uint64_t xpq3 = xp / primes[i-3];
+
+      sum += (segmentedPi[xpq0] * 2 - b + 2) +
+             (segmentedPi[xpq1] * 2 - b + 2) +
+             (segmentedPi[xpq2] * 2 - b + 2) +
+             (segmentedPi[xpq3] * 2 - b + 2);
+    }
+
+    for (; i > pi_min_m; i--)
+    {
+      uint64_t xpq = xp / primes[i];
+      sum += segmentedPi[xpq] * 2 - b + 2;
+    }
   }
-
-  // Find all sparse easy leaves where
-  // successive leaves are different.
-  // pq = primes[b] * primes[i]
-  // Which satisfy: low <= x / pq < high && q <= y && pq > z
-  // where phi(x / pq, b - 1) = pi(x / pq) - b + 2
-  for (; i > pi_min_m; i--)
+  else if (!overlaps_conjugate)
   {
-    uint64_t xpq = xp / primes[i];
-    sum += segmentedPi[xpq] - b + 2;
+    // This segment has no reflected terms.
+    for (; i > pi_min_m + 3; i -= 4)
+    {
+      uint64_t xpq0 = xp / primes[i];
+      uint64_t xpq1 = xp / primes[i-1];
+      uint64_t xpq2 = xp / primes[i-2];
+      uint64_t xpq3 = xp / primes[i-3];
+
+      sum += (segmentedPi[xpq0] - b + 2) +
+             (segmentedPi[xpq1] - b + 2) +
+             (segmentedPi[xpq2] - b + 2) +
+             (segmentedPi[xpq3] - b + 2);
+    }
+
+    for (; i > pi_min_m; i--)
+    {
+      uint64_t xpq = xp / primes[i];
+      sum += segmentedPi[xpq] - b + 2;
+    }
+  }
+  else
+  {
+    // Only segments crossing a clustered endpoint need range tests.
+    for (; i > pi_min_m + 3; i -= 4)
+    {
+      uint64_t xpq0 = xp / primes[i];
+      uint64_t xpq1 = xp / primes[i-1];
+      uint64_t xpq2 = xp / primes[i-2];
+      uint64_t xpq3 = xp / primes[i-3];
+      T pix0 = segmentedPi[xpq0];
+      T pix1 = segmentedPi[xpq1];
+      T pix2 = segmentedPi[xpq2];
+      T pix3 = segmentedPi[xpq3];
+
+      sum += (pix0 - b + 2) +
+             (pix1 - b + 2) +
+             (pix2 - b + 2) +
+             (pix3 - b + 2);
+
+      if (min_clustered_global < xpq0 &&
+          xpq0 < max_clustered_global)
+        sum += pix0;
+      if (min_clustered_global < xpq1 &&
+          xpq1 < max_clustered_global)
+        sum += pix1;
+      if (min_clustered_global < xpq2 &&
+          xpq2 < max_clustered_global)
+        sum += pix2;
+      if (min_clustered_global < xpq3 &&
+          xpq3 < max_clustered_global)
+        sum += pix3;
+    }
+
+    for (; i > pi_min_m; i--)
+    {
+      uint64_t xpq = xp / primes[i];
+      T pix = segmentedPi[xpq];
+      sum += pix - b + 2;
+
+      if (min_clustered_global < xpq &&
+          xpq < max_clustered_global)
+        sum += pix;
+    }
   }
 
   return sum;
@@ -691,6 +824,8 @@ T C2_128(T xlow,
          T xp,
          uint64_t y,
          uint64_t b,
+         uint64_t pi_y,
+         uint64_t max_y_prime,
          const Primes& primes,
          const PiTable& pi,
          const SegmentedPiTable& segmentedPi)
@@ -703,79 +838,143 @@ T C2_128(T xlow,
   uint64_t min_m = min(min_m128, max_m);
   uint64_t i = pi[max_m];
   uint64_t pi_min_m = pi[min_m];
-  uint64_t min_clustered = (uint64_t) isqrt(xp);
-  min_clustered = in_between(min_m, min_clustered, max_m);
+  uint64_t sqrt_xp = (uint64_t) isqrt(xp);
+  uint64_t min_clustered = in_between(min_m, sqrt_xp, max_m);
   uint64_t pi_min_clustered = pi[min_clustered];
+  T min_clustered128 =
+      max3(xp / (prime * prime), (T) prime, (T) sqrt_xp);
+  uint64_t min_clustered_global =
+      (uint64_t) min(min_clustered128, (T) y);
+  uint64_t max_clustered_global = max_y_prime;
+  bool has_clustered =
+      max_clustered_global > min_clustered_global;
 
-  // Clustered easy leaves: q in ]min_clustered, max_m], where
-  // x / (p*q) < √(x / p). Gourdon's inversion equality turns this
-  // band into a sum over the conjugate range (t = x / p):
-  //
-  //   sum_{min_clustered < q <= max_m} pi(t / q) =
-  //     pi(q_lo) * pi(max_m) - pi(q_hi) * pi(min_clustered)
-  //     + sum_{q_lo < q <= q_hi} pi(t / q)
-  //
-  // The conjugate arguments t / q are <= y, hence they are read
-  // from the pi table instead of segmentedPi.
+  // For fixed p, ]min_clustered_global, max_clustered_global] is
+  // the complete clustered interval. Emit its boundary correction
+  // once, in the unique segment containing max_clustered_global.
+  // The reflected terms are accumulated by the sparse loops below,
+  // possibly in other segments. All contributions use the existing
+  // OpenMP reduction, hence no synchronization is needed.
   if (i > pi_min_clustered)
   {
-    uint64_t q_lo = fast_div64(xp, max_m);
-    uint64_t q_hi = fast_div64(xp, min_clustered + 1);
-    uint64_t pi_q_lo = pi[q_lo];
-    uint64_t pi_q_hi = pi[q_hi];
-    uint64_t j = pi_q_hi;
-
-    T conj_sum = 0;
-
-    // Unroll loop to increase instruction level parallelism
-    for (; j > pi_q_lo + 3; j -= 4)
+    if (has_clustered && i == pi_y)
     {
-      uint64_t xpq0 = fast_div64(xp, primes[j]);
-      uint64_t xpq1 = fast_div64(xp, primes[j-1]);
-      uint64_t xpq2 = fast_div64(xp, primes[j-2]);
-      uint64_t xpq3 = fast_div64(xp, primes[j-3]);
+      uint64_t q_lo =
+          fast_div64(xp, max_clustered_global);
+      uint64_t q_hi =
+          fast_div64(xp, min_clustered_global + 1);
+      uint64_t pi_q_lo = pi[q_lo];
+      uint64_t pi_q_hi = pi[q_hi];
+      uint64_t pi_min_clustered_global =
+          pi[min_clustered_global];
 
-      conj_sum += pi[xpq0] +
-                  pi[xpq1] +
-                  pi[xpq2] +
-                  pi[xpq3];
+      sum += T(pi_q_lo) * pi_y
+           - T(pi_q_hi) * pi_min_clustered_global;
+      sum -= T(b - 2) *
+             (pi_y - pi_min_clustered_global);
     }
-
-    for (; j > pi_q_lo; j--)
-    {
-      uint64_t xpq = fast_div64(xp, primes[j]);
-      conj_sum += pi[xpq];
-    }
-
-    sum += T(pi_q_lo) * i - T(pi_q_hi) * pi_min_clustered + conj_sum;
-    sum -= T(b - 2) * (i - pi_min_clustered);
 
     i = pi_min_clustered;
   }
 
-  // Unroll loop to increase instruction level parallelism
-  for (; i > pi_min_m + 3; i -= 4)
-  {
-    uint64_t xpq0 = fast_div64(xp, primes[i]);
-    uint64_t xpq1 = fast_div64(xp, primes[i-1]);
-    uint64_t xpq2 = fast_div64(xp, primes[i-2]);
-    uint64_t xpq3 = fast_div64(xp, primes[i-3]);
+  uint64_t segment_low = (uint64_t) segmentedPi.low();
+  uint64_t segment_high = (uint64_t) segmentedPi.high();
+  bool all_conjugate =
+      has_clustered &&
+      segment_low > min_clustered_global &&
+      segment_high <= max_clustered_global;
+  bool overlaps_conjugate =
+      has_clustered &&
+      segment_high > min_clustered_global + 1 &&
+      segment_low < max_clustered_global;
 
-    sum += (segmentedPi[xpq0] - b + 2) +
-           (segmentedPi[xpq1] - b + 2) +
-           (segmentedPi[xpq2] - b + 2) +
-           (segmentedPi[xpq3] - b + 2);
+  if (all_conjugate)
+  {
+    // Every sparse leaf in this segment is also reflected.
+    for (; i > pi_min_m + 3; i -= 4)
+    {
+      uint64_t xpq0 = fast_div64(xp, primes[i]);
+      uint64_t xpq1 = fast_div64(xp, primes[i-1]);
+      uint64_t xpq2 = fast_div64(xp, primes[i-2]);
+      uint64_t xpq3 = fast_div64(xp, primes[i-3]);
+
+      sum += (segmentedPi[xpq0] * 2 - b + 2) +
+             (segmentedPi[xpq1] * 2 - b + 2) +
+             (segmentedPi[xpq2] * 2 - b + 2) +
+             (segmentedPi[xpq3] * 2 - b + 2);
+    }
+
+    for (; i > pi_min_m; i--)
+    {
+      uint64_t xpq = fast_div64(xp, primes[i]);
+      sum += segmentedPi[xpq] * 2 - b + 2;
+    }
   }
-
-  // Find all sparse easy leaves where
-  // successive leaves are different.
-  // pq = primes[b] * primes[i]
-  // Which satisfy: low <= x / pq < high && q <= y && pq > z
-  // where phi(x / pq, b - 1) = pi(x / pq) - b + 2
-  for (; i > pi_min_m; i--)
+  else if (!overlaps_conjugate)
   {
-    uint64_t xpq = fast_div64(xp, primes[i]);
-    sum += segmentedPi[xpq] - b + 2;
+    // This segment has no reflected terms.
+    for (; i > pi_min_m + 3; i -= 4)
+    {
+      uint64_t xpq0 = fast_div64(xp, primes[i]);
+      uint64_t xpq1 = fast_div64(xp, primes[i-1]);
+      uint64_t xpq2 = fast_div64(xp, primes[i-2]);
+      uint64_t xpq3 = fast_div64(xp, primes[i-3]);
+
+      sum += (segmentedPi[xpq0] - b + 2) +
+             (segmentedPi[xpq1] - b + 2) +
+             (segmentedPi[xpq2] - b + 2) +
+             (segmentedPi[xpq3] - b + 2);
+    }
+
+    for (; i > pi_min_m; i--)
+    {
+      uint64_t xpq = fast_div64(xp, primes[i]);
+      sum += segmentedPi[xpq] - b + 2;
+    }
+  }
+  else
+  {
+    // Only segments crossing a clustered endpoint need range tests.
+    for (; i > pi_min_m + 3; i -= 4)
+    {
+      uint64_t xpq0 = fast_div64(xp, primes[i]);
+      uint64_t xpq1 = fast_div64(xp, primes[i-1]);
+      uint64_t xpq2 = fast_div64(xp, primes[i-2]);
+      uint64_t xpq3 = fast_div64(xp, primes[i-3]);
+      T pix0 = segmentedPi[xpq0];
+      T pix1 = segmentedPi[xpq1];
+      T pix2 = segmentedPi[xpq2];
+      T pix3 = segmentedPi[xpq3];
+
+      sum += (pix0 - b + 2) +
+             (pix1 - b + 2) +
+             (pix2 - b + 2) +
+             (pix3 - b + 2);
+
+      if (min_clustered_global < xpq0 &&
+          xpq0 < max_clustered_global)
+        sum += pix0;
+      if (min_clustered_global < xpq1 &&
+          xpq1 < max_clustered_global)
+        sum += pix1;
+      if (min_clustered_global < xpq2 &&
+          xpq2 < max_clustered_global)
+        sum += pix2;
+      if (min_clustered_global < xpq3 &&
+          xpq3 < max_clustered_global)
+        sum += pix3;
+    }
+
+    for (; i > pi_min_m; i--)
+    {
+      uint64_t xpq = fast_div64(xp, primes[i]);
+      T pix = segmentedPi[xpq];
+      sum += pix - b + 2;
+
+      if (min_clustered_global < xpq &&
+          xpq < max_clustered_global)
+        sum += pix;
+    }
   }
 
   return sum;
@@ -820,7 +1019,8 @@ T AC_OpenMP(T x,
   // is fairly large and does not fit into the CPU's cache.
   PiTable pi(max(z, max_a_prime), threads);
 
-  int64_t pi_y = pi[y];
+  uint64_t pi_y = pi[y];
+  uint64_t max_y_prime = pi_y ? primes[pi_y] : 0;
   int64_t pi_sqrtz = pi[isqrt(z)];
   int64_t pi_root3_xy = pi[iroot<3>(xy)];
   int64_t pi_root3_xz = pi[iroot<3>(xz)];
@@ -907,9 +1107,9 @@ T AC_OpenMP(T x,
           T xp = x / prime;
 
           if (xp <= pstd::numeric_limits<uint64_t>::max())
-            sum += C2_64(xlow, xhigh, (uint64_t) xp, y, b, prime, lprimes, pi, segmentedPi);
+            sum += C2_64(xlow, xhigh, (uint64_t) xp, y, b, pi_y, max_y_prime, prime, lprimes, pi, segmentedPi);
           else
-            sum += C2_128(xlow, xhigh, xp, y, b, primes, pi, segmentedPi);
+            sum += C2_128(xlow, xhigh, xp, y, b, pi_y, max_y_prime, primes, pi, segmentedPi);
         }
 
         // A formula: pi[x_star] < b <= pi[x13]

--- a/src/gourdon/AC.cpp
+++ b/src/gourdon/AC.cpp
@@ -202,12 +202,12 @@ T C2(T xlow,
   if (pi_max_m > pi_min_clustered &&
       pi_max_m == pi_y)
   {
-    uint64_t pi_q_lo = pi[fast_div64(xp, max_clustered_global)];
-    uint64_t pi_q_hi = pi[fast_div64(xp, min_clustered_global + 1)];
+    uint64_t q_lo = fast_div64(xp, max_clustered_global);
+    uint64_t q_hi = fast_div64(xp, min_clustered_global + 1);
     uint64_t pi_min_clustered_global = pi[min_clustered_global];
 
-    sum += T(pi_q_lo) * pi_y
-         - T(pi_q_hi) * pi_min_clustered_global;
+    sum += T(pi[q_lo]) * pi_y
+         - T(pi[q_hi]) * pi_min_clustered_global;
     sum -= T(b - 2) *
            (pi_y - pi_min_clustered_global);
   }
@@ -626,12 +626,12 @@ T C2_64(T xlow,
   if (pi_max_m > pi_min_clustered &&
       pi_max_m == pi_y)
   {
-    uint64_t pi_q_lo = pi[fast_div64(xp, max_clustered_global)];
-    uint64_t pi_q_hi = pi[fast_div64(xp, min_clustered_global + 1)];
+    uint64_t q_lo = fast_div64(xp, max_clustered_global);
+    uint64_t q_hi = fast_div64(xp, min_clustered_global + 1);
     uint64_t pi_min_clustered_global = pi[min_clustered_global];
 
-    sum += T(pi_q_lo) * pi_y
-         - T(pi_q_hi) * pi_min_clustered_global;
+    sum += T(pi[q_lo]) * pi_y
+         - T(pi[q_hi]) * pi_min_clustered_global;
     sum -= T(b - 2) *
            (pi_y - pi_min_clustered_global);
   }
@@ -737,12 +737,12 @@ T C2_128(T xlow,
   if (pi_max_m > pi_min_clustered &&
       pi_max_m == pi_y)
   {
-    uint64_t pi_q_lo = pi[fast_div64(xp, max_clustered_global)];
-    uint64_t pi_q_hi = pi[fast_div64(xp, min_clustered_global + 1)];
+    uint64_t q_lo = fast_div64(xp, max_clustered_global);
+    uint64_t q_hi = fast_div64(xp, min_clustered_global + 1);
     uint64_t pi_min_clustered_global = pi[min_clustered_global];
 
-    sum += T(pi_q_lo) * pi_y
-         - T(pi_q_hi) * pi_min_clustered_global;
+    sum += T(pi[q_lo]) * pi_y
+         - T(pi[q_hi]) * pi_min_clustered_global;
     sum -= T(b - 2) *
            (pi_y - pi_min_clustered_global);
   }

--- a/src/gourdon/AC.cpp
+++ b/src/gourdon/AC.cpp
@@ -81,6 +81,7 @@ T A(T xlow,
 
   // pq = primes[b] * primes[i]
   // x / pq >= y && low <= x / pq < high
+  NOUNROLL_LOOP
   for (; i <= max_i1; i++)
   {
     uint64_t xpq = fast_div64(xp, primes[i]);
@@ -103,6 +104,7 @@ T A(T xlow,
 
   // pq = primes[b] * primes[i]
   // x / pq < y && low <= x / pq < high
+  NOUNROLL_LOOP
   for (; i <= max_i2; i++)
   {
     uint64_t xpq = fast_div64(xp, primes[i]);
@@ -221,20 +223,51 @@ T C2(T xlow,
   }
 
   // Sparse leaves below the reflected range
+  NOUNROLL_LOOP
   for (; i <= pi_conj_lo; i++)
   {
     uint64_t xpq = fast_div64(xp, primes[i]);
     sum += segmentedPi[xpq] - b + 2;
   }
 
-  // Reflected leaves: counted once as a sparse leaf, once as a conjugate
+  // Reflected leaves: counted once as a sparse leaf, once as a conjugate.
+  // Unroll loop to increase instruction level parallelism.
+  for (; i + 3 <= pi_conj_hi; i += 4)
+  {
+    uint64_t xpq0 = fast_div64(xp, primes[i]);
+    uint64_t xpq1 = fast_div64(xp, primes[i+1]);
+    uint64_t xpq2 = fast_div64(xp, primes[i+2]);
+    uint64_t xpq3 = fast_div64(xp, primes[i+3]);
+
+    sum += (segmentedPi[xpq0] * 2 - b + 2) +
+           (segmentedPi[xpq1] * 2 - b + 2) +
+           (segmentedPi[xpq2] * 2 - b + 2) +
+           (segmentedPi[xpq3] * 2 - b + 2);
+  }
+
+  NOUNROLL_LOOP
   for (; i <= pi_conj_hi; i++)
   {
     uint64_t xpq = fast_div64(xp, primes[i]);
     sum += segmentedPi[xpq] * 2 - b + 2;
   }
 
-  // Sparse leaves above the reflected range
+  // Sparse leaves above the reflected range.
+  // Unroll loop to increase instruction level parallelism.
+  for (; i + 3 <= pi_min_clustered; i += 4)
+  {
+    uint64_t xpq0 = fast_div64(xp, primes[i]);
+    uint64_t xpq1 = fast_div64(xp, primes[i+1]);
+    uint64_t xpq2 = fast_div64(xp, primes[i+2]);
+    uint64_t xpq3 = fast_div64(xp, primes[i+3]);
+
+    sum += (segmentedPi[xpq0] - b + 2) +
+           (segmentedPi[xpq1] - b + 2) +
+           (segmentedPi[xpq2] - b + 2) +
+           (segmentedPi[xpq3] - b + 2);
+  }
+
+  NOUNROLL_LOOP
   for (; i <= pi_min_clustered; i++)
   {
     uint64_t xpq = fast_div64(xp, primes[i]);
@@ -421,6 +454,7 @@ T A_64(T xlow,
 
   // pq = primes[b] * primes[i]
   // x / pq >= y && low <= x / pq < high
+  NOUNROLL_LOOP
   for (; i <= max_i1; i++)
   {
     uint64_t xpq = xp / primes[i];
@@ -443,6 +477,7 @@ T A_64(T xlow,
 
   // pq = primes[b] * primes[i]
   // x / pq < y && low <= x / pq < high
+  NOUNROLL_LOOP
   for (; i <= max_i2; i++)
   {
     uint64_t xpq = xp / primes[i];
@@ -479,6 +514,7 @@ T A_128(T xlow,
 
   // pq = primes[b] * primes[i]
   // x / pq >= y && low <= x / pq < high
+  NOUNROLL_LOOP
   for (; i <= max_i1; i++)
   {
     uint64_t xpq = fast_div64(xp, primes[i]);
@@ -501,6 +537,7 @@ T A_128(T xlow,
 
   // pq = primes[b] * primes[i]
   // x / pq < y && low <= x / pq < high
+  NOUNROLL_LOOP
   for (; i <= max_i2; i++)
   {
     uint64_t xpq = fast_div64(xp, primes[i]);
@@ -618,20 +655,51 @@ T C2_64(T xlow,
   }
 
   // Sparse leaves below the reflected range
+  NOUNROLL_LOOP
   for (; i <= pi_conj_lo; i++)
   {
     uint64_t xpq = xp / primes[i];
     sum += segmentedPi[xpq] - b + 2;
   }
 
-  // Reflected leaves: counted once as a sparse leaf, once as a conjugate
+  // Reflected leaves: counted once as a sparse leaf, once as a conjugate.
+  // Unroll loop to increase instruction level parallelism.
+  for (; i + 3 <= pi_conj_hi; i += 4)
+  {
+    uint64_t xpq0 = xp / primes[i];
+    uint64_t xpq1 = xp / primes[i+1];
+    uint64_t xpq2 = xp / primes[i+2];
+    uint64_t xpq3 = xp / primes[i+3];
+
+    sum += (segmentedPi[xpq0] * 2 - b + 2) +
+           (segmentedPi[xpq1] * 2 - b + 2) +
+           (segmentedPi[xpq2] * 2 - b + 2) +
+           (segmentedPi[xpq3] * 2 - b + 2);
+  }
+
+  NOUNROLL_LOOP
   for (; i <= pi_conj_hi; i++)
   {
     uint64_t xpq = xp / primes[i];
     sum += segmentedPi[xpq] * 2 - b + 2;
   }
 
-  // Sparse leaves above the reflected range
+  // Sparse leaves above the reflected range.
+  // Unroll loop to increase instruction level parallelism.
+  for (; i + 3 <= pi_min_clustered; i += 4)
+  {
+    uint64_t xpq0 = xp / primes[i];
+    uint64_t xpq1 = xp / primes[i+1];
+    uint64_t xpq2 = xp / primes[i+2];
+    uint64_t xpq3 = xp / primes[i+3];
+
+    sum += (segmentedPi[xpq0] - b + 2) +
+           (segmentedPi[xpq1] - b + 2) +
+           (segmentedPi[xpq2] - b + 2) +
+           (segmentedPi[xpq3] - b + 2);
+  }
+
+  NOUNROLL_LOOP
   for (; i <= pi_min_clustered; i++)
   {
     uint64_t xpq = xp / primes[i];
@@ -702,20 +770,51 @@ T C2_128(T xlow,
   }
 
   // Sparse leaves below the reflected range
+  NOUNROLL_LOOP
   for (; i <= pi_conj_lo; i++)
   {
     uint64_t xpq = fast_div64(xp, primes[i]);
     sum += segmentedPi[xpq] - b + 2;
   }
 
-  // Reflected leaves: counted once as a sparse leaf, once as a conjugate
+  // Reflected leaves: counted once as a sparse leaf, once as a conjugate.
+  // Unroll loop to increase instruction level parallelism.
+  for (; i + 3 <= pi_conj_hi; i += 4)
+  {
+    uint64_t xpq0 = fast_div64(xp, primes[i]);
+    uint64_t xpq1 = fast_div64(xp, primes[i+1]);
+    uint64_t xpq2 = fast_div64(xp, primes[i+2]);
+    uint64_t xpq3 = fast_div64(xp, primes[i+3]);
+
+    sum += (segmentedPi[xpq0] * 2 - b + 2) +
+           (segmentedPi[xpq1] * 2 - b + 2) +
+           (segmentedPi[xpq2] * 2 - b + 2) +
+           (segmentedPi[xpq3] * 2 - b + 2);
+  }
+
+  NOUNROLL_LOOP
   for (; i <= pi_conj_hi; i++)
   {
     uint64_t xpq = fast_div64(xp, primes[i]);
     sum += segmentedPi[xpq] * 2 - b + 2;
   }
 
-  // Sparse leaves above the reflected range
+  // Sparse leaves above the reflected range.
+  // Unroll loop to increase instruction level parallelism.
+  for (; i + 3 <= pi_min_clustered; i += 4)
+  {
+    uint64_t xpq0 = fast_div64(xp, primes[i]);
+    uint64_t xpq1 = fast_div64(xp, primes[i+1]);
+    uint64_t xpq2 = fast_div64(xp, primes[i+2]);
+    uint64_t xpq3 = fast_div64(xp, primes[i+3]);
+
+    sum += (segmentedPi[xpq0] - b + 2) +
+           (segmentedPi[xpq1] - b + 2) +
+           (segmentedPi[xpq2] - b + 2) +
+           (segmentedPi[xpq3] - b + 2);
+  }
+
+  NOUNROLL_LOOP
   for (; i <= pi_min_clustered; i++)
   {
     uint64_t xpq = fast_div64(xp, primes[i]);

--- a/src/gourdon/AC.cpp
+++ b/src/gourdon/AC.cpp
@@ -183,7 +183,7 @@ T C2(T xlow,
 
   uint64_t prime = primes[b];
   uint64_t max_m = min3(xlow / prime, xp / prime, y);
-  XP x_div_prime3 = xp / (prime * prime);
+  uint64_t x_div_prime3 = fast_div64(xp, prime * prime);
   T min_m128 = max3(xhigh / prime, x_div_prime3, prime);
   uint64_t min_m = min(min_m128, max_m);
   uint64_t pi_max_m = pi[max_m];
@@ -191,7 +191,8 @@ T C2(T xlow,
   uint64_t sqrt_xp = (uint64_t) isqrt(xp);
   uint64_t min_clustered = in_between(min_m, sqrt_xp, max_m);
   uint64_t pi_min_clustered = pi[min_clustered];
-  uint64_t min_clustered_global = min(max3(x_div_prime3, prime, sqrt_xp), y);
+  uint64_t min_clustered_global = max3(x_div_prime3, sqrt_xp, prime);
+  min_clustered_global = min(min_clustered_global, y);
   uint64_t pi_conj_lo = pi_min_m;
   uint64_t pi_conj_hi = pi_min_m;
   uint64_t i = pi_min_m + 1;
@@ -588,7 +589,8 @@ T C2_64(T xlow,
   uint64_t sqrt_xp = isqrt(xp);
   uint64_t min_clustered = in_between(min_m, sqrt_xp, max_m);
   uint64_t pi_min_clustered = pi[min_clustered];
-  uint64_t min_clustered_global = min(max3(x_div_prime3, prime, sqrt_xp), y);
+  uint64_t min_clustered_global = max3(x_div_prime3, sqrt_xp, prime);
+  min_clustered_global = min(min_clustered_global, y);
   uint64_t pi_conj_lo = pi_min_m;
   uint64_t pi_conj_hi = pi_min_m;
   uint64_t i = pi_min_m + 1;
@@ -664,7 +666,7 @@ T C2_128(T xlow,
 
   uint64_t prime = primes[b];
   uint64_t max_m = min3(xlow / prime, xp / prime, y);
-  T x_div_prime3 = xp / (prime * prime);
+  uint64_t x_div_prime3 = fast_div64(xp, prime * prime);
   T min_m128 = max3(xhigh / prime, x_div_prime3, prime);
   uint64_t min_m = min(min_m128, max_m);
   uint64_t pi_max_m = pi[max_m];
@@ -672,7 +674,8 @@ T C2_128(T xlow,
   uint64_t sqrt_xp = (uint64_t) isqrt(xp);
   uint64_t min_clustered = in_between(min_m, sqrt_xp, max_m);
   uint64_t pi_min_clustered = pi[min_clustered];
-  uint64_t min_clustered_global = min(max3(x_div_prime3, prime, sqrt_xp), y);
+  uint64_t min_clustered_global = max3(x_div_prime3, sqrt_xp, prime);
+  min_clustered_global = min(min_clustered_global, y);
   uint64_t pi_conj_lo = pi_min_m;
   uint64_t pi_conj_hi = pi_min_m;
   uint64_t i = pi_min_m + 1;

--- a/src/gourdon/AC.cpp
+++ b/src/gourdon/AC.cpp
@@ -183,13 +183,14 @@ T C2(T xlow,
 
   uint64_t prime = primes[b];
   uint64_t max_m = min3(xlow / prime, xp / prime, y);
-  T min_m128 = max3(xhigh / prime, xp / (prime * prime), prime);
+  XP x_div_prime3 = xp / (prime * prime);
+  T min_m128 = max3(xhigh / prime, x_div_prime3, prime);
   uint64_t min_m = min(min_m128, max_m);
   uint64_t pi_max_m = pi[max_m];
   uint64_t pi_min_m = pi[min_m];
   uint64_t sqrt_xp = (uint64_t) isqrt(xp);
   uint64_t pi_min_clustered = pi[in_between(min_m, sqrt_xp, max_m)];
-  uint64_t min_clustered_global = min(max3(xp / (prime * prime), prime, sqrt_xp), y);
+  uint64_t min_clustered_global = min(max3(x_div_prime3, prime, sqrt_xp), y);
   uint64_t pi_conj_lo = pi_min_m;
   uint64_t pi_conj_hi = pi_min_m;
   uint64_t i = pi_min_m + 1;
@@ -578,13 +579,14 @@ T C2_64(T xlow,
   T sum = 0;
 
   uint64_t max_m = min3(xlow / prime, xp / prime, y);
-  T min_m128 = max3(xhigh / prime, xp / (prime * prime), prime);
+  uint64_t x_div_prime3 = xp / (prime * prime);
+  T min_m128 = max3(xhigh / prime, x_div_prime3, prime);
   uint64_t min_m = min(min_m128, max_m);
   uint64_t pi_max_m = pi[max_m];
   uint64_t pi_min_m = pi[min_m];
   uint64_t sqrt_xp = isqrt(xp);
   uint64_t pi_min_clustered = pi[in_between(min_m, sqrt_xp, max_m)];
-  uint64_t min_clustered_global = min(max3(xp / (prime * prime), prime, sqrt_xp), y);
+  uint64_t min_clustered_global = min(max3(x_div_prime3, prime, sqrt_xp), y);
   uint64_t pi_conj_lo = pi_min_m;
   uint64_t pi_conj_hi = pi_min_m;
   uint64_t i = pi_min_m + 1;
@@ -660,13 +662,14 @@ T C2_128(T xlow,
 
   uint64_t prime = primes[b];
   uint64_t max_m = min3(xlow / prime, xp / prime, y);
-  T min_m128 = max3(xhigh / prime, xp / (prime * prime), prime);
+  T x_div_prime3 = xp / (prime * prime);
+  T min_m128 = max3(xhigh / prime, x_div_prime3, prime);
   uint64_t min_m = min(min_m128, max_m);
   uint64_t pi_max_m = pi[max_m];
   uint64_t pi_min_m = pi[min_m];
   uint64_t sqrt_xp = (uint64_t) isqrt(xp);
   uint64_t pi_min_clustered = pi[in_between(min_m, sqrt_xp, max_m)];
-  uint64_t min_clustered_global = min(max3(xp / (prime * prime), prime, sqrt_xp), y);
+  uint64_t min_clustered_global = min(max3(x_div_prime3, prime, sqrt_xp), y);
   uint64_t pi_conj_lo = pi_min_m;
   uint64_t pi_conj_hi = pi_min_m;
   uint64_t i = pi_min_m + 1;

--- a/src/gourdon/AC.cpp
+++ b/src/gourdon/AC.cpp
@@ -234,19 +234,6 @@ T C2(T xlow,
   if (all_conjugate)
   {
     // Every sparse leaf in this segment is also reflected.
-    for (; i > pi_min_m + 3; i -= 4)
-    {
-      uint64_t xpq0 = fast_div64(xp, primes[i]);
-      uint64_t xpq1 = fast_div64(xp, primes[i-1]);
-      uint64_t xpq2 = fast_div64(xp, primes[i-2]);
-      uint64_t xpq3 = fast_div64(xp, primes[i-3]);
-
-      sum += (segmentedPi[xpq0] * 2 - b + 2) +
-             (segmentedPi[xpq1] * 2 - b + 2) +
-             (segmentedPi[xpq2] * 2 - b + 2) +
-             (segmentedPi[xpq3] * 2 - b + 2);
-    }
-
     for (; i > pi_min_m; i--)
     {
       uint64_t xpq = fast_div64(xp, primes[i]);
@@ -256,19 +243,6 @@ T C2(T xlow,
   else if (!overlaps_conjugate)
   {
     // This segment has no reflected terms.
-    for (; i > pi_min_m + 3; i -= 4)
-    {
-      uint64_t xpq0 = fast_div64(xp, primes[i]);
-      uint64_t xpq1 = fast_div64(xp, primes[i-1]);
-      uint64_t xpq2 = fast_div64(xp, primes[i-2]);
-      uint64_t xpq3 = fast_div64(xp, primes[i-3]);
-
-      sum += (segmentedPi[xpq0] - b + 2) +
-             (segmentedPi[xpq1] - b + 2) +
-             (segmentedPi[xpq2] - b + 2) +
-             (segmentedPi[xpq3] - b + 2);
-    }
-
     for (; i > pi_min_m; i--)
     {
       uint64_t xpq = fast_div64(xp, primes[i]);
@@ -277,46 +251,33 @@ T C2(T xlow,
   }
   else
   {
-    // Only segments crossing a clustered endpoint need range tests.
-    for (; i > pi_min_m + 3; i -= 4)
+    // Only segments crossing a clustered endpoint reach this path.
+    // Since xp / primes[i] increases as i decreases, the reflected
+    // leaves form one contiguous prime-index interval.
+    uint64_t q_lo = fast_div64(xp, max_clustered_global);
+    uint64_t q_hi = fast_div64(xp, min_clustered_global + 1);
+    uint64_t pi_conjugate_lo = max(pi[q_lo], pi_min_m);
+    uint64_t pi_conjugate_hi = max(pi[q_hi], pi_conjugate_lo);
+
+    // Sparse leaves before the reflected interval.
+    for (; i > pi_conjugate_hi; i--)
     {
-      uint64_t xpq0 = fast_div64(xp, primes[i]);
-      uint64_t xpq1 = fast_div64(xp, primes[i-1]);
-      uint64_t xpq2 = fast_div64(xp, primes[i-2]);
-      uint64_t xpq3 = fast_div64(xp, primes[i-3]);
-      T pix0 = segmentedPi[xpq0];
-      T pix1 = segmentedPi[xpq1];
-      T pix2 = segmentedPi[xpq2];
-      T pix3 = segmentedPi[xpq3];
-
-      sum += (pix0 - b + 2) +
-             (pix1 - b + 2) +
-             (pix2 - b + 2) +
-             (pix3 - b + 2);
-
-      if (min_clustered_global < xpq0 &&
-          xpq0 < max_clustered_global)
-        sum += pix0;
-      if (min_clustered_global < xpq1 &&
-          xpq1 < max_clustered_global)
-        sum += pix1;
-      if (min_clustered_global < xpq2 &&
-          xpq2 < max_clustered_global)
-        sum += pix2;
-      if (min_clustered_global < xpq3 &&
-          xpq3 < max_clustered_global)
-        sum += pix3;
+      uint64_t xpq = fast_div64(xp, primes[i]);
+      sum += segmentedPi[xpq] - b + 2;
     }
 
+    // Every leaf in this interval is also reflected.
+    for (; i > pi_conjugate_lo; i--)
+    {
+      uint64_t xpq = fast_div64(xp, primes[i]);
+      sum += segmentedPi[xpq] * 2 - b + 2;
+    }
+
+    // Sparse leaves after the reflected interval.
     for (; i > pi_min_m; i--)
     {
       uint64_t xpq = fast_div64(xp, primes[i]);
-      T pix = segmentedPi[xpq];
-      sum += pix - b + 2;
-
-      if (min_clustered_global < xpq &&
-          xpq < max_clustered_global)
-        sum += pix;
+      sum += segmentedPi[xpq] - b + 2;
     }
   }
 
@@ -710,19 +671,6 @@ T C2_64(T xlow,
   if (all_conjugate)
   {
     // Every sparse leaf in this segment is also reflected.
-    for (; i > pi_min_m + 3; i -= 4)
-    {
-      uint64_t xpq0 = xp / primes[i];
-      uint64_t xpq1 = xp / primes[i-1];
-      uint64_t xpq2 = xp / primes[i-2];
-      uint64_t xpq3 = xp / primes[i-3];
-
-      sum += (segmentedPi[xpq0] * 2 - b + 2) +
-             (segmentedPi[xpq1] * 2 - b + 2) +
-             (segmentedPi[xpq2] * 2 - b + 2) +
-             (segmentedPi[xpq3] * 2 - b + 2);
-    }
-
     for (; i > pi_min_m; i--)
     {
       uint64_t xpq = xp / primes[i];
@@ -732,19 +680,6 @@ T C2_64(T xlow,
   else if (!overlaps_conjugate)
   {
     // This segment has no reflected terms.
-    for (; i > pi_min_m + 3; i -= 4)
-    {
-      uint64_t xpq0 = xp / primes[i];
-      uint64_t xpq1 = xp / primes[i-1];
-      uint64_t xpq2 = xp / primes[i-2];
-      uint64_t xpq3 = xp / primes[i-3];
-
-      sum += (segmentedPi[xpq0] - b + 2) +
-             (segmentedPi[xpq1] - b + 2) +
-             (segmentedPi[xpq2] - b + 2) +
-             (segmentedPi[xpq3] - b + 2);
-    }
-
     for (; i > pi_min_m; i--)
     {
       uint64_t xpq = xp / primes[i];
@@ -753,46 +688,33 @@ T C2_64(T xlow,
   }
   else
   {
-    // Only segments crossing a clustered endpoint need range tests.
-    for (; i > pi_min_m + 3; i -= 4)
+    // Only segments crossing a clustered endpoint reach this path.
+    // Since xp / primes[i] increases as i decreases, the reflected
+    // leaves form one contiguous prime-index interval.
+    uint64_t q_lo = fast_div64(xp, max_clustered_global);
+    uint64_t q_hi = fast_div64(xp, min_clustered_global + 1);
+    uint64_t pi_conjugate_lo = max(pi[q_lo], pi_min_m);
+    uint64_t pi_conjugate_hi = max(pi[q_hi], pi_conjugate_lo);
+
+    // Sparse leaves before the reflected interval.
+    for (; i > pi_conjugate_hi; i--)
     {
-      uint64_t xpq0 = xp / primes[i];
-      uint64_t xpq1 = xp / primes[i-1];
-      uint64_t xpq2 = xp / primes[i-2];
-      uint64_t xpq3 = xp / primes[i-3];
-      T pix0 = segmentedPi[xpq0];
-      T pix1 = segmentedPi[xpq1];
-      T pix2 = segmentedPi[xpq2];
-      T pix3 = segmentedPi[xpq3];
-
-      sum += (pix0 - b + 2) +
-             (pix1 - b + 2) +
-             (pix2 - b + 2) +
-             (pix3 - b + 2);
-
-      if (min_clustered_global < xpq0 &&
-          xpq0 < max_clustered_global)
-        sum += pix0;
-      if (min_clustered_global < xpq1 &&
-          xpq1 < max_clustered_global)
-        sum += pix1;
-      if (min_clustered_global < xpq2 &&
-          xpq2 < max_clustered_global)
-        sum += pix2;
-      if (min_clustered_global < xpq3 &&
-          xpq3 < max_clustered_global)
-        sum += pix3;
+      uint64_t xpq = xp / primes[i];
+      sum += segmentedPi[xpq] - b + 2;
     }
 
+    // Every leaf in this interval is also reflected.
+    for (; i > pi_conjugate_lo; i--)
+    {
+      uint64_t xpq = xp / primes[i];
+      sum += segmentedPi[xpq] * 2 - b + 2;
+    }
+
+    // Sparse leaves after the reflected interval.
     for (; i > pi_min_m; i--)
     {
       uint64_t xpq = xp / primes[i];
-      T pix = segmentedPi[xpq];
-      sum += pix - b + 2;
-
-      if (min_clustered_global < xpq &&
-          xpq < max_clustered_global)
-        sum += pix;
+      sum += segmentedPi[xpq] - b + 2;
     }
   }
 
@@ -873,19 +795,6 @@ T C2_128(T xlow,
   if (all_conjugate)
   {
     // Every sparse leaf in this segment is also reflected.
-    for (; i > pi_min_m + 3; i -= 4)
-    {
-      uint64_t xpq0 = fast_div64(xp, primes[i]);
-      uint64_t xpq1 = fast_div64(xp, primes[i-1]);
-      uint64_t xpq2 = fast_div64(xp, primes[i-2]);
-      uint64_t xpq3 = fast_div64(xp, primes[i-3]);
-
-      sum += (segmentedPi[xpq0] * 2 - b + 2) +
-             (segmentedPi[xpq1] * 2 - b + 2) +
-             (segmentedPi[xpq2] * 2 - b + 2) +
-             (segmentedPi[xpq3] * 2 - b + 2);
-    }
-
     for (; i > pi_min_m; i--)
     {
       uint64_t xpq = fast_div64(xp, primes[i]);
@@ -895,19 +804,6 @@ T C2_128(T xlow,
   else if (!overlaps_conjugate)
   {
     // This segment has no reflected terms.
-    for (; i > pi_min_m + 3; i -= 4)
-    {
-      uint64_t xpq0 = fast_div64(xp, primes[i]);
-      uint64_t xpq1 = fast_div64(xp, primes[i-1]);
-      uint64_t xpq2 = fast_div64(xp, primes[i-2]);
-      uint64_t xpq3 = fast_div64(xp, primes[i-3]);
-
-      sum += (segmentedPi[xpq0] - b + 2) +
-             (segmentedPi[xpq1] - b + 2) +
-             (segmentedPi[xpq2] - b + 2) +
-             (segmentedPi[xpq3] - b + 2);
-    }
-
     for (; i > pi_min_m; i--)
     {
       uint64_t xpq = fast_div64(xp, primes[i]);
@@ -916,46 +812,33 @@ T C2_128(T xlow,
   }
   else
   {
-    // Only segments crossing a clustered endpoint need range tests.
-    for (; i > pi_min_m + 3; i -= 4)
+    // Only segments crossing a clustered endpoint reach this path.
+    // Since xp / primes[i] increases as i decreases, the reflected
+    // leaves form one contiguous prime-index interval.
+    uint64_t q_lo = fast_div64(xp, max_clustered_global);
+    uint64_t q_hi = fast_div64(xp, min_clustered_global + 1);
+    uint64_t pi_conjugate_lo = max(pi[q_lo], pi_min_m);
+    uint64_t pi_conjugate_hi = max(pi[q_hi], pi_conjugate_lo);
+
+    // Sparse leaves before the reflected interval.
+    for (; i > pi_conjugate_hi; i--)
     {
-      uint64_t xpq0 = fast_div64(xp, primes[i]);
-      uint64_t xpq1 = fast_div64(xp, primes[i-1]);
-      uint64_t xpq2 = fast_div64(xp, primes[i-2]);
-      uint64_t xpq3 = fast_div64(xp, primes[i-3]);
-      T pix0 = segmentedPi[xpq0];
-      T pix1 = segmentedPi[xpq1];
-      T pix2 = segmentedPi[xpq2];
-      T pix3 = segmentedPi[xpq3];
-
-      sum += (pix0 - b + 2) +
-             (pix1 - b + 2) +
-             (pix2 - b + 2) +
-             (pix3 - b + 2);
-
-      if (min_clustered_global < xpq0 &&
-          xpq0 < max_clustered_global)
-        sum += pix0;
-      if (min_clustered_global < xpq1 &&
-          xpq1 < max_clustered_global)
-        sum += pix1;
-      if (min_clustered_global < xpq2 &&
-          xpq2 < max_clustered_global)
-        sum += pix2;
-      if (min_clustered_global < xpq3 &&
-          xpq3 < max_clustered_global)
-        sum += pix3;
+      uint64_t xpq = fast_div64(xp, primes[i]);
+      sum += segmentedPi[xpq] - b + 2;
     }
 
+    // Every leaf in this interval is also reflected.
+    for (; i > pi_conjugate_lo; i--)
+    {
+      uint64_t xpq = fast_div64(xp, primes[i]);
+      sum += segmentedPi[xpq] * 2 - b + 2;
+    }
+
+    // Sparse leaves after the reflected interval.
     for (; i > pi_min_m; i--)
     {
       uint64_t xpq = fast_div64(xp, primes[i]);
-      T pix = segmentedPi[xpq];
-      sum += pix - b + 2;
-
-      if (min_clustered_global < xpq &&
-          xpq < max_clustered_global)
-        sum += pix;
+      sum += segmentedPi[xpq] - b + 2;
     }
   }
 

--- a/src/gourdon/AC.cpp
+++ b/src/gourdon/AC.cpp
@@ -197,8 +197,7 @@ T C2(T xlow,
   uint64_t pi_conj_hi = pi_min_m;
   uint64_t i = pi_min_m + 1;
 
-  // Emit the boundary correction once, in the unique
-  // segment containing max_clustered_global.
+  // Compute the boundary correction once
   if (pi_max_m == pi_y &&
       pi_max_m > pi_min_clustered)
   {
@@ -209,7 +208,7 @@ T C2(T xlow,
     sum -= T(b - 2) * (pi_y - pi_min_clustered_global);
   }
 
-  // Reflected leaves occupy the contiguous ]pi_conj_lo, pi_conj_hi]
+  // Reflected range: ]pi_conj_lo, pi_conj_hi]
   if (min_clustered_global < max_clustered_global &&
       segmentedPi.low() < max_clustered_global &&
       segmentedPi.high() > min_clustered_global + 1)
@@ -221,7 +220,7 @@ T C2(T xlow,
     pi_conj_hi = max(pi_conj_hi, pi_conj_lo);
   }
 
-  // Sparse leaves below the reflected sub-range
+  // Sparse leaves below the reflected range
   for (; i <= pi_conj_lo; i++)
   {
     uint64_t xpq = fast_div64(xp, primes[i]);
@@ -235,7 +234,7 @@ T C2(T xlow,
     sum += segmentedPi[xpq] * 2 - b + 2;
   }
 
-  // Sparse leaves above the reflected sub-range
+  // Sparse leaves above the reflected range
   for (; i <= pi_min_clustered; i++)
   {
     uint64_t xpq = fast_div64(xp, primes[i]);
@@ -595,8 +594,7 @@ T C2_64(T xlow,
   uint64_t pi_conj_hi = pi_min_m;
   uint64_t i = pi_min_m + 1;
 
-  // Emit the boundary correction once, in the unique
-  // segment containing max_clustered_global.
+  // Compute the boundary correction once
   if (pi_max_m == pi_y &&
       pi_max_m > pi_min_clustered)
   {
@@ -607,7 +605,7 @@ T C2_64(T xlow,
     sum -= T(b - 2) * (pi_y - pi_min_clustered_global);
   }
 
-  // Reflected leaves occupy the contiguous ]pi_conj_lo, pi_conj_hi]
+  // Reflected range: ]pi_conj_lo, pi_conj_hi]
   if (min_clustered_global < max_clustered_global &&
       segmentedPi.low() < max_clustered_global &&
       segmentedPi.high() > min_clustered_global + 1)
@@ -619,7 +617,7 @@ T C2_64(T xlow,
     pi_conj_hi = max(pi_conj_hi, pi_conj_lo);
   }
 
-  // Sparse leaves below the reflected sub-range
+  // Sparse leaves below the reflected range
   for (; i <= pi_conj_lo; i++)
   {
     uint64_t xpq = xp / primes[i];
@@ -633,7 +631,7 @@ T C2_64(T xlow,
     sum += segmentedPi[xpq] * 2 - b + 2;
   }
 
-  // Sparse leaves above the reflected sub-range
+  // Sparse leaves above the reflected range
   for (; i <= pi_min_clustered; i++)
   {
     uint64_t xpq = xp / primes[i];
@@ -680,8 +678,7 @@ T C2_128(T xlow,
   uint64_t pi_conj_hi = pi_min_m;
   uint64_t i = pi_min_m + 1;
 
-  // Emit the boundary correction once, in the unique
-  // segment containing max_clustered_global.
+  // Compute the boundary correction once
   if (pi_max_m == pi_y &&
       pi_max_m > pi_min_clustered)
   {
@@ -692,7 +689,7 @@ T C2_128(T xlow,
     sum -= T(b - 2) * (pi_y - pi_min_clustered_global);
   }
 
-  // Reflected leaves occupy the contiguous ]pi_conj_lo, pi_conj_hi]
+  // Reflected range: ]pi_conj_lo, pi_conj_hi]
   if (min_clustered_global < max_clustered_global &&
       segmentedPi.low() < max_clustered_global &&
       segmentedPi.high() > min_clustered_global + 1)
@@ -704,7 +701,7 @@ T C2_128(T xlow,
     pi_conj_hi = max(pi_conj_hi, pi_conj_lo);
   }
 
-  // Sparse leaves below the reflected sub-range
+  // Sparse leaves below the reflected range
   for (; i <= pi_conj_lo; i++)
   {
     uint64_t xpq = fast_div64(xp, primes[i]);
@@ -718,7 +715,7 @@ T C2_128(T xlow,
     sum += segmentedPi[xpq] * 2 - b + 2;
   }
 
-  // Sparse leaves above the reflected sub-range
+  // Sparse leaves above the reflected range
   for (; i <= pi_min_clustered; i++)
   {
     uint64_t xpq = fast_div64(xp, primes[i]);

--- a/src/gourdon/AC.cpp
+++ b/src/gourdon/AC.cpp
@@ -224,7 +224,7 @@ T C2(T xlow,
       sum += segmentedPi[xpq] * 2 - b + 2;
     }
   }
-  else if (max_clustered_global <= min_clustered_global ||
+  else if (min_clustered_global >= max_clustered_global ||
            segmentedPi.high() <= min_clustered_global + 1 ||
            segmentedPi.low() >= max_clustered_global)
   {
@@ -648,7 +648,7 @@ T C2_64(T xlow,
       sum += segmentedPi[xpq] * 2 - b + 2;
     }
   }
-  else if (max_clustered_global <= min_clustered_global ||
+  else if (min_clustered_global >= max_clustered_global ||
            segmentedPi.high() <= min_clustered_global + 1 ||
            segmentedPi.low() >= max_clustered_global)
   {
@@ -759,7 +759,7 @@ T C2_128(T xlow,
       sum += segmentedPi[xpq] * 2 - b + 2;
     }
   }
-  else if (max_clustered_global <= min_clustered_global ||
+  else if (min_clustered_global >= max_clustered_global ||
            segmentedPi.high() <= min_clustered_global + 1 ||
            segmentedPi.low() >= max_clustered_global)
   {

--- a/src/gourdon/AC.cpp
+++ b/src/gourdon/AC.cpp
@@ -192,7 +192,6 @@ T C2(T xlow,
   uint64_t pi_min_clustered = pi[min_clustered];
   uint64_t min_clustered_global = min(
       max3(xp / (prime * prime), prime, sqrt_xp), y);
-  bool has_clustered = max_clustered_global > min_clustered_global;
 
   // For fixed p, ]min_clustered_global, max_clustered_global] is
   // the complete clustered interval. Emit its boundary correction
@@ -200,25 +199,22 @@ T C2(T xlow,
   // The reflected terms are accumulated by the sparse loops below,
   // possibly in other segments. All contributions use the existing
   // OpenMP reduction, hence no synchronization is needed.
-  if (i > pi_min_clustered)
+  if (i > pi_min_clustered &&
+      i == pi_y)
   {
-    if (has_clustered && i == pi_y)
-    {
-      uint64_t pi_q_lo = pi[fast_div64(xp, max_clustered_global)];
-      uint64_t pi_q_hi = pi[fast_div64(xp, min_clustered_global + 1)];
-      uint64_t pi_min_clustered_global = pi[min_clustered_global];
+    uint64_t pi_q_lo = pi[fast_div64(xp, max_clustered_global)];
+    uint64_t pi_q_hi = pi[fast_div64(xp, min_clustered_global + 1)];
+    uint64_t pi_min_clustered_global = pi[min_clustered_global];
 
-      sum += T(pi_q_lo) * pi_y
-           - T(pi_q_hi) * pi_min_clustered_global;
-      sum -= T(b - 2) *
-             (pi_y - pi_min_clustered_global);
-    }
-
-    i = pi_min_clustered;
+    sum += T(pi_q_lo) * pi_y
+         - T(pi_q_hi) * pi_min_clustered_global;
+    sum -= T(b - 2) *
+           (pi_y - pi_min_clustered_global);
   }
 
-  if (has_clustered &&
-      segmentedPi.low() > min_clustered_global &&
+  i = pi_min_clustered;
+
+  if (segmentedPi.low() > min_clustered_global &&
       segmentedPi.high() <= max_clustered_global)
   {
     // Every sparse leaf in this segment is also reflected.
@@ -228,7 +224,7 @@ T C2(T xlow,
       sum += segmentedPi[xpq] * 2 - b + 2;
     }
   }
-  else if (!has_clustered ||
+  else if (max_clustered_global <= min_clustered_global ||
            segmentedPi.high() <= min_clustered_global + 1 ||
            segmentedPi.low() >= max_clustered_global)
   {
@@ -620,7 +616,6 @@ T C2_64(T xlow,
   uint64_t pi_min_clustered = pi[min_clustered];
   uint64_t min_clustered_global = min(
       max3(xp / (prime * prime), prime, sqrt_xp), y);
-  bool has_clustered = max_clustered_global > min_clustered_global;
 
   // For fixed p, ]min_clustered_global, max_clustered_global] is
   // the complete clustered interval. Emit its boundary correction
@@ -628,25 +623,22 @@ T C2_64(T xlow,
   // The reflected terms are accumulated by the sparse loops below,
   // possibly in other segments. All contributions use the existing
   // OpenMP reduction, hence no synchronization is needed.
-  if (i > pi_min_clustered)
+  if (i > pi_min_clustered &&
+      i == pi_y)
   {
-    if (has_clustered && i == pi_y)
-    {
-      uint64_t pi_q_lo = pi[fast_div64(xp, max_clustered_global)];
-      uint64_t pi_q_hi = pi[fast_div64(xp, min_clustered_global + 1)];
-      uint64_t pi_min_clustered_global = pi[min_clustered_global];
+    uint64_t pi_q_lo = pi[fast_div64(xp, max_clustered_global)];
+    uint64_t pi_q_hi = pi[fast_div64(xp, min_clustered_global + 1)];
+    uint64_t pi_min_clustered_global = pi[min_clustered_global];
 
-      sum += T(pi_q_lo) * pi_y
-           - T(pi_q_hi) * pi_min_clustered_global;
-      sum -= T(b - 2) *
-             (pi_y - pi_min_clustered_global);
-    }
-
-    i = pi_min_clustered;
+    sum += T(pi_q_lo) * pi_y
+         - T(pi_q_hi) * pi_min_clustered_global;
+    sum -= T(b - 2) *
+           (pi_y - pi_min_clustered_global);
   }
 
-  if (has_clustered &&
-      segmentedPi.low() > min_clustered_global &&
+  i = pi_min_clustered;
+
+  if (segmentedPi.low() > min_clustered_global &&
       segmentedPi.high() <= max_clustered_global)
   {
     // Every sparse leaf in this segment is also reflected.
@@ -656,7 +648,7 @@ T C2_64(T xlow,
       sum += segmentedPi[xpq] * 2 - b + 2;
     }
   }
-  else if (!has_clustered ||
+  else if (max_clustered_global <= min_clustered_global ||
            segmentedPi.high() <= min_clustered_global + 1 ||
            segmentedPi.low() >= max_clustered_global)
   {
@@ -735,7 +727,6 @@ T C2_128(T xlow,
   uint64_t pi_min_clustered = pi[min_clustered];
   uint64_t min_clustered_global = min(
       max3(xp / (prime * prime), prime, sqrt_xp), y);
-  bool has_clustered = max_clustered_global > min_clustered_global;
 
   // For fixed p, ]min_clustered_global, max_clustered_global] is
   // the complete clustered interval. Emit its boundary correction
@@ -743,25 +734,22 @@ T C2_128(T xlow,
   // The reflected terms are accumulated by the sparse loops below,
   // possibly in other segments. All contributions use the existing
   // OpenMP reduction, hence no synchronization is needed.
-  if (i > pi_min_clustered)
+  if (i > pi_min_clustered &&
+      i == pi_y)
   {
-    if (has_clustered && i == pi_y)
-    {
-      uint64_t pi_q_lo = pi[fast_div64(xp, max_clustered_global)];
-      uint64_t pi_q_hi = pi[fast_div64(xp, min_clustered_global + 1)];
-      uint64_t pi_min_clustered_global = pi[min_clustered_global];
+    uint64_t pi_q_lo = pi[fast_div64(xp, max_clustered_global)];
+    uint64_t pi_q_hi = pi[fast_div64(xp, min_clustered_global + 1)];
+    uint64_t pi_min_clustered_global = pi[min_clustered_global];
 
-      sum += T(pi_q_lo) * pi_y
-           - T(pi_q_hi) * pi_min_clustered_global;
-      sum -= T(b - 2) *
-             (pi_y - pi_min_clustered_global);
-    }
-
-    i = pi_min_clustered;
+    sum += T(pi_q_lo) * pi_y
+         - T(pi_q_hi) * pi_min_clustered_global;
+    sum -= T(b - 2) *
+           (pi_y - pi_min_clustered_global);
   }
 
-  if (has_clustered &&
-      segmentedPi.low() > min_clustered_global &&
+  i = pi_min_clustered;
+
+  if (segmentedPi.low() > min_clustered_global &&
       segmentedPi.high() <= max_clustered_global)
   {
     // Every sparse leaf in this segment is also reflected.
@@ -771,7 +759,7 @@ T C2_128(T xlow,
       sum += segmentedPi[xpq] * 2 - b + 2;
     }
   }
-  else if (!has_clustered ||
+  else if (max_clustered_global <= min_clustered_global ||
            segmentedPi.high() <= min_clustered_global + 1 ||
            segmentedPi.low() >= max_clustered_global)
   {

--- a/src/gourdon/AC.cpp
+++ b/src/gourdon/AC.cpp
@@ -189,7 +189,8 @@ T C2(T xlow,
   uint64_t pi_max_m = pi[max_m];
   uint64_t pi_min_m = pi[min_m];
   uint64_t sqrt_xp = (uint64_t) isqrt(xp);
-  uint64_t pi_min_clustered = pi[in_between(min_m, sqrt_xp, max_m)];
+  uint64_t min_clustered = in_between(min_m, sqrt_xp, max_m);
+  uint64_t pi_min_clustered = pi[min_clustered];
   uint64_t min_clustered_global = min(max3(x_div_prime3, prime, sqrt_xp), y);
   uint64_t pi_conj_lo = pi_min_m;
   uint64_t pi_conj_hi = pi_min_m;
@@ -585,7 +586,8 @@ T C2_64(T xlow,
   uint64_t pi_max_m = pi[max_m];
   uint64_t pi_min_m = pi[min_m];
   uint64_t sqrt_xp = isqrt(xp);
-  uint64_t pi_min_clustered = pi[in_between(min_m, sqrt_xp, max_m)];
+  uint64_t min_clustered = in_between(min_m, sqrt_xp, max_m);
+  uint64_t pi_min_clustered = pi[min_clustered];
   uint64_t min_clustered_global = min(max3(x_div_prime3, prime, sqrt_xp), y);
   uint64_t pi_conj_lo = pi_min_m;
   uint64_t pi_conj_hi = pi_min_m;
@@ -668,7 +670,8 @@ T C2_128(T xlow,
   uint64_t pi_max_m = pi[max_m];
   uint64_t pi_min_m = pi[min_m];
   uint64_t sqrt_xp = (uint64_t) isqrt(xp);
-  uint64_t pi_min_clustered = pi[in_between(min_m, sqrt_xp, max_m)];
+  uint64_t min_clustered = in_between(min_m, sqrt_xp, max_m);
+  uint64_t pi_min_clustered = pi[min_clustered];
   uint64_t min_clustered_global = min(max3(x_div_prime3, prime, sqrt_xp), y);
   uint64_t pi_conj_lo = pi_min_m;
   uint64_t pi_conj_hi = pi_min_m;

--- a/src/gourdon/AC.cpp
+++ b/src/gourdon/AC.cpp
@@ -183,16 +183,16 @@ T C2(T xlow,
 
   uint64_t prime = primes[b];
   uint64_t max_m = min3(xlow / prime, xp / prime, y);
-  uint64_t min_m = min(max3(xhigh / prime, xp / (prime * prime), prime), max_m);
+  T min_m128 = max3(xhigh / prime, xp / (prime * prime), prime);
+  uint64_t min_m = min(min_m128, max_m);
   uint64_t pi_max_m = pi[max_m];
   uint64_t pi_min_m = pi[min_m];
   uint64_t sqrt_xp = (uint64_t) isqrt(xp);
   uint64_t pi_min_clustered = pi[in_between(min_m, sqrt_xp, max_m)];
   uint64_t min_clustered_global = min(max3(xp / (prime * prime), prime, sqrt_xp), y);
-
-  uint64_t i = pi_min_m + 1;
   uint64_t pi_conj_lo = pi_min_m;
   uint64_t pi_conj_hi = pi_min_m;
+  uint64_t i = pi_min_m + 1;
 
   // Emit the boundary correction once, in the unique
   // segment containing max_clustered_global.
@@ -578,16 +578,16 @@ T C2_64(T xlow,
   T sum = 0;
 
   uint64_t max_m = min3(xlow / prime, xp / prime, y);
-  uint64_t min_m = min(max3(xhigh / prime, xp / (prime * prime), prime), max_m);
+  T min_m128 = max3(xhigh / prime, xp / (prime * prime), prime);
+  uint64_t min_m = min(min_m128, max_m);
   uint64_t pi_max_m = pi[max_m];
   uint64_t pi_min_m = pi[min_m];
   uint64_t sqrt_xp = isqrt(xp);
   uint64_t pi_min_clustered = pi[in_between(min_m, sqrt_xp, max_m)];
   uint64_t min_clustered_global = min(max3(xp / (prime * prime), prime, sqrt_xp), y);
-
-  uint64_t i = pi_min_m + 1;
   uint64_t pi_conj_lo = pi_min_m;
   uint64_t pi_conj_hi = pi_min_m;
+  uint64_t i = pi_min_m + 1;
 
   // Emit the boundary correction once, in the unique
   // segment containing max_clustered_global.
@@ -660,16 +660,16 @@ T C2_128(T xlow,
 
   uint64_t prime = primes[b];
   uint64_t max_m = min3(xlow / prime, xp / prime, y);
-  uint64_t min_m = min(max3(xhigh / prime, xp / (prime * prime), prime), max_m);
+  T min_m128 = max3(xhigh / prime, xp / (prime * prime), prime);
+  uint64_t min_m = min(min_m128, max_m);
   uint64_t pi_max_m = pi[max_m];
   uint64_t pi_min_m = pi[min_m];
   uint64_t sqrt_xp = (uint64_t) isqrt(xp);
   uint64_t pi_min_clustered = pi[in_between(min_m, sqrt_xp, max_m)];
   uint64_t min_clustered_global = min(max3(xp / (prime * prime), prime, sqrt_xp), y);
-
-  uint64_t i = pi_min_m + 1;
   uint64_t pi_conj_lo = pi_min_m;
   uint64_t pi_conj_hi = pi_min_m;
+  uint64_t i = pi_min_m + 1;
 
   // Emit the boundary correction once, in the unique
   // segment containing max_clustered_global.

--- a/src/gourdon/AC.cpp
+++ b/src/gourdon/AC.cpp
@@ -190,7 +190,7 @@ T C2(T xlow,
   uint64_t pi_min_clustered = pi[in_between(min_m, sqrt_xp, max_m)];
   uint64_t min_clustered_global = min(max3(xp / (prime * prime), prime, sqrt_xp), y);
 
-  uint64_t i = pi_min_clustered;
+  uint64_t i = pi_min_m + 1;
   uint64_t pi_conj_lo = pi_min_m;
   uint64_t pi_conj_hi = pi_min_m;
 
@@ -227,22 +227,22 @@ T C2(T xlow,
     pi_conj_hi = max(min(pi_q_hi, pi_min_clustered), pi_conj_lo);
   }
 
-  // Sparse leaves above the reflected sub-range.
-  for (; i > pi_conj_hi; i--)
+  // Sparse leaves below the reflected sub-range.
+  for (; i <= pi_conj_lo; i++)
   {
     uint64_t xpq = fast_div64(xp, primes[i]);
     sum += segmentedPi[xpq] - b + 2;
   }
 
   // Reflected leaves: counted once as a sparse leaf, once as a conjugate.
-  for (; i > pi_conj_lo; i--)
+  for (; i <= pi_conj_hi; i++)
   {
     uint64_t xpq = fast_div64(xp, primes[i]);
     sum += segmentedPi[xpq] * 2 - b + 2;
   }
 
-  // Sparse leaves below the reflected sub-range.
-  for (; i > pi_min_m; i--)
+  // Sparse leaves above the reflected sub-range.
+  for (; i <= pi_min_clustered; i++)
   {
     uint64_t xpq = fast_div64(xp, primes[i]);
     sum += segmentedPi[xpq] - b + 2;
@@ -594,7 +594,7 @@ T C2_64(T xlow,
   uint64_t pi_min_clustered = pi[in_between(min_m, sqrt_xp, max_m)];
   uint64_t min_clustered_global = min(max3(xp / (prime * prime), prime, sqrt_xp), y);
 
-  uint64_t i = pi_min_clustered;
+  uint64_t i = pi_min_m + 1;
   uint64_t pi_conj_lo = pi_min_m;
   uint64_t pi_conj_hi = pi_min_m;
 
@@ -631,22 +631,22 @@ T C2_64(T xlow,
     pi_conj_hi = max(min(pi_q_hi, pi_min_clustered), pi_conj_lo);
   }
 
-  // Sparse leaves above the reflected sub-range.
-  for (; i > pi_conj_hi; i--)
+  // Sparse leaves below the reflected sub-range.
+  for (; i <= pi_conj_lo; i++)
   {
     uint64_t xpq = xp / primes[i];
     sum += segmentedPi[xpq] - b + 2;
   }
 
   // Reflected leaves: counted once as a sparse leaf, once as a conjugate.
-  for (; i > pi_conj_lo; i--)
+  for (; i <= pi_conj_hi; i++)
   {
     uint64_t xpq = xp / primes[i];
     sum += segmentedPi[xpq] * 2 - b + 2;
   }
 
-  // Sparse leaves below the reflected sub-range.
-  for (; i > pi_min_m; i--)
+  // Sparse leaves above the reflected sub-range.
+  for (; i <= pi_min_clustered; i++)
   {
     uint64_t xpq = xp / primes[i];
     sum += segmentedPi[xpq] - b + 2;
@@ -685,7 +685,7 @@ T C2_128(T xlow,
   uint64_t pi_min_clustered = pi[in_between(min_m, sqrt_xp, max_m)];
   uint64_t min_clustered_global = min(max3(xp / (prime * prime), prime, sqrt_xp), y);
 
-  uint64_t i = pi_min_clustered;
+  uint64_t i = pi_min_m + 1;
   uint64_t pi_conj_lo = pi_min_m;
   uint64_t pi_conj_hi = pi_min_m;
 
@@ -722,22 +722,22 @@ T C2_128(T xlow,
     pi_conj_hi = max(min(pi_q_hi, pi_min_clustered), pi_conj_lo);
   }
 
-  // Sparse leaves above the reflected sub-range.
-  for (; i > pi_conj_hi; i--)
+  // Sparse leaves below the reflected sub-range.
+  for (; i <= pi_conj_lo; i++)
   {
     uint64_t xpq = fast_div64(xp, primes[i]);
     sum += segmentedPi[xpq] - b + 2;
   }
 
   // Reflected leaves: counted once as a sparse leaf, once as a conjugate.
-  for (; i > pi_conj_lo; i--)
+  for (; i <= pi_conj_hi; i++)
   {
     uint64_t xpq = fast_div64(xp, primes[i]);
     sum += segmentedPi[xpq] * 2 - b + 2;
   }
 
-  // Sparse leaves below the reflected sub-range.
-  for (; i > pi_min_m; i--)
+  // Sparse leaves above the reflected sub-range.
+  for (; i <= pi_min_clustered; i++)
   {
     uint64_t xpq = fast_div64(xp, primes[i]);
     sum += segmentedPi[xpq] - b + 2;

--- a/src/gourdon/AC.cpp
+++ b/src/gourdon/AC.cpp
@@ -217,11 +217,9 @@ T C2(T xlow,
     i = pi_min_clustered;
   }
 
-  uint64_t segment_low = (uint64_t) segmentedPi.low();
-  uint64_t segment_high = (uint64_t) segmentedPi.high();
   if (has_clustered &&
-      segment_low > min_clustered_global &&
-      segment_high <= max_clustered_global)
+      segmentedPi.low() > min_clustered_global &&
+      segmentedPi.high() <= max_clustered_global)
   {
     // Every sparse leaf in this segment is also reflected.
     for (; i > pi_min_m; i--)
@@ -231,8 +229,8 @@ T C2(T xlow,
     }
   }
   else if (!has_clustered ||
-           segment_high <= min_clustered_global + 1 ||
-           segment_low >= max_clustered_global)
+           segmentedPi.high() <= min_clustered_global + 1 ||
+           segmentedPi.low() >= max_clustered_global)
   {
     // This segment has no reflected terms.
     for (; i > pi_min_m; i--)
@@ -647,11 +645,9 @@ T C2_64(T xlow,
     i = pi_min_clustered;
   }
 
-  uint64_t segment_low = (uint64_t) segmentedPi.low();
-  uint64_t segment_high = (uint64_t) segmentedPi.high();
   if (has_clustered &&
-      segment_low > min_clustered_global &&
-      segment_high <= max_clustered_global)
+      segmentedPi.low() > min_clustered_global &&
+      segmentedPi.high() <= max_clustered_global)
   {
     // Every sparse leaf in this segment is also reflected.
     for (; i > pi_min_m; i--)
@@ -661,8 +657,8 @@ T C2_64(T xlow,
     }
   }
   else if (!has_clustered ||
-           segment_high <= min_clustered_global + 1 ||
-           segment_low >= max_clustered_global)
+           segmentedPi.high() <= min_clustered_global + 1 ||
+           segmentedPi.low() >= max_clustered_global)
   {
     // This segment has no reflected terms.
     for (; i > pi_min_m; i--)
@@ -764,11 +760,9 @@ T C2_128(T xlow,
     i = pi_min_clustered;
   }
 
-  uint64_t segment_low = (uint64_t) segmentedPi.low();
-  uint64_t segment_high = (uint64_t) segmentedPi.high();
   if (has_clustered &&
-      segment_low > min_clustered_global &&
-      segment_high <= max_clustered_global)
+      segmentedPi.low() > min_clustered_global &&
+      segmentedPi.high() <= max_clustered_global)
   {
     // Every sparse leaf in this segment is also reflected.
     for (; i > pi_min_m; i--)
@@ -778,8 +772,8 @@ T C2_128(T xlow,
     }
   }
   else if (!has_clustered ||
-           segment_high <= min_clustered_global + 1 ||
-           segment_low >= max_clustered_global)
+           segmentedPi.high() <= min_clustered_global + 1 ||
+           segmentedPi.low() >= max_clustered_global)
   {
     // This segment has no reflected terms.
     for (; i > pi_min_m; i--)

--- a/src/gourdon/AC.cpp
+++ b/src/gourdon/AC.cpp
@@ -194,37 +194,28 @@ T C2(T xlow,
   uint64_t pi_conj_lo = pi_min_m;
   uint64_t pi_conj_hi = pi_min_m;
 
-  // For fixed p, ]min_clustered_global, max_clustered_global] is the
-  // complete clustered interval. Gourdon's inversion equality replaces
-  // its whole contribution by a one-time boundary correction plus a sum
-  // of reflected leaves pi(xp / r). The boundary correction is emitted
-  // once, in the unique segment containing max_clustered_global. The
-  // reflected leaves are the sparse leaves whose xpq lies in the
-  // clustered interval; they are counted a second time by the sparse
-  // loops below, here and in the other segments overlapping the
-  // interval. All contributions enter the existing OpenMP reduction.
-  bool emit = pi_max_m == pi_y && pi_max_m > pi_min_clustered;
-  bool overlap = min_clustered_global < max_clustered_global &&
-                 segmentedPi.low() < max_clustered_global &&
-                 segmentedPi.high() > min_clustered_global + 1;
-
-  if (emit || overlap)
+  // Emit the boundary correction once, in the unique
+  // segment containing max_clustered_global.
+  if (pi_max_m == pi_y &&
+      pi_max_m > pi_min_clustered)
   {
     uint64_t q_lo = fast_div64(xp, max_clustered_global);
     uint64_t q_hi = fast_div64(xp, min_clustered_global + 1);
-    uint64_t pi_q_lo = pi[q_lo];
-    uint64_t pi_q_hi = pi[q_hi];
+    uint64_t pi_min_clustered_global = pi[min_clustered_global];
+    sum += T(pi[q_lo]) * pi_y - T(pi[q_hi]) * pi_min_clustered_global;
+    sum -= T(b - 2) * (pi_y - pi_min_clustered_global);
+  }
 
-    if (emit)
-    {
-      uint64_t pi_min_clustered_global = pi[min_clustered_global];
-      sum += T(pi_q_lo) * pi_y - T(pi_q_hi) * pi_min_clustered_global;
-      sum -= T(b - 2) * (pi_y - pi_min_clustered_global);
-    }
-
-    // Reflected leaves occupy the contiguous ]pi_conj_lo, pi_conj_hi].
-    pi_conj_lo = max(pi_q_lo, pi_min_m);
-    pi_conj_hi = max(min(pi_q_hi, pi_min_clustered), pi_conj_lo);
+  // Reflected leaves occupy the contiguous ]pi_conj_lo, pi_conj_hi].
+  if (min_clustered_global < max_clustered_global &&
+      segmentedPi.low() < max_clustered_global &&
+      segmentedPi.high() > min_clustered_global + 1)
+  {
+    uint64_t q_lo = fast_div64(xp, max_clustered_global);
+    uint64_t q_hi = fast_div64(xp, min_clustered_global + 1);
+    pi_conj_lo = max(pi[q_lo], pi_min_m);
+    pi_conj_hi = min(pi[q_hi], pi_min_clustered);
+    pi_conj_hi = max(pi_conj_hi, pi_conj_lo);
   }
 
   // Sparse leaves below the reflected sub-range.
@@ -598,37 +589,28 @@ T C2_64(T xlow,
   uint64_t pi_conj_lo = pi_min_m;
   uint64_t pi_conj_hi = pi_min_m;
 
-  // For fixed p, ]min_clustered_global, max_clustered_global] is the
-  // complete clustered interval. Gourdon's inversion equality replaces
-  // its whole contribution by a one-time boundary correction plus a sum
-  // of reflected leaves pi(xp / r). The boundary correction is emitted
-  // once, in the unique segment containing max_clustered_global. The
-  // reflected leaves are the sparse leaves whose xpq lies in the
-  // clustered interval; they are counted a second time by the sparse
-  // loops below, here and in the other segments overlapping the
-  // interval. All contributions enter the existing OpenMP reduction.
-  bool emit = pi_max_m == pi_y && pi_max_m > pi_min_clustered;
-  bool overlap = min_clustered_global < max_clustered_global &&
-                 segmentedPi.low() < max_clustered_global &&
-                 segmentedPi.high() > min_clustered_global + 1;
-
-  if (emit || overlap)
+  // Emit the boundary correction once, in the unique
+  // segment containing max_clustered_global.
+  if (pi_max_m == pi_y &&
+      pi_max_m > pi_min_clustered)
   {
     uint64_t q_lo = fast_div64(xp, max_clustered_global);
     uint64_t q_hi = fast_div64(xp, min_clustered_global + 1);
-    uint64_t pi_q_lo = pi[q_lo];
-    uint64_t pi_q_hi = pi[q_hi];
+    uint64_t pi_min_clustered_global = pi[min_clustered_global];
+    sum += T(pi[q_lo]) * pi_y - T(pi[q_hi]) * pi_min_clustered_global;
+    sum -= T(b - 2) * (pi_y - pi_min_clustered_global);
+  }
 
-    if (emit)
-    {
-      uint64_t pi_min_clustered_global = pi[min_clustered_global];
-      sum += T(pi_q_lo) * pi_y - T(pi_q_hi) * pi_min_clustered_global;
-      sum -= T(b - 2) * (pi_y - pi_min_clustered_global);
-    }
-
-    // Reflected leaves occupy the contiguous ]pi_conj_lo, pi_conj_hi].
-    pi_conj_lo = max(pi_q_lo, pi_min_m);
-    pi_conj_hi = max(min(pi_q_hi, pi_min_clustered), pi_conj_lo);
+  // Reflected leaves occupy the contiguous ]pi_conj_lo, pi_conj_hi].
+  if (min_clustered_global < max_clustered_global &&
+      segmentedPi.low() < max_clustered_global &&
+      segmentedPi.high() > min_clustered_global + 1)
+  {
+    uint64_t q_lo = fast_div64(xp, max_clustered_global);
+    uint64_t q_hi = fast_div64(xp, min_clustered_global + 1);
+    pi_conj_lo = max(pi[q_lo], pi_min_m);
+    pi_conj_hi = min(pi[q_hi], pi_min_clustered);
+    pi_conj_hi = max(pi_conj_hi, pi_conj_lo);
   }
 
   // Sparse leaves below the reflected sub-range.
@@ -689,37 +671,28 @@ T C2_128(T xlow,
   uint64_t pi_conj_lo = pi_min_m;
   uint64_t pi_conj_hi = pi_min_m;
 
-  // For fixed p, ]min_clustered_global, max_clustered_global] is the
-  // complete clustered interval. Gourdon's inversion equality replaces
-  // its whole contribution by a one-time boundary correction plus a sum
-  // of reflected leaves pi(xp / r). The boundary correction is emitted
-  // once, in the unique segment containing max_clustered_global. The
-  // reflected leaves are the sparse leaves whose xpq lies in the
-  // clustered interval; they are counted a second time by the sparse
-  // loops below, here and in the other segments overlapping the
-  // interval. All contributions enter the existing OpenMP reduction.
-  bool emit = pi_max_m == pi_y && pi_max_m > pi_min_clustered;
-  bool overlap = min_clustered_global < max_clustered_global &&
-                 segmentedPi.low() < max_clustered_global &&
-                 segmentedPi.high() > min_clustered_global + 1;
-
-  if (emit || overlap)
+  // Emit the boundary correction once, in the unique
+  // segment containing max_clustered_global.
+  if (pi_max_m == pi_y &&
+      pi_max_m > pi_min_clustered)
   {
     uint64_t q_lo = fast_div64(xp, max_clustered_global);
     uint64_t q_hi = fast_div64(xp, min_clustered_global + 1);
-    uint64_t pi_q_lo = pi[q_lo];
-    uint64_t pi_q_hi = pi[q_hi];
+    uint64_t pi_min_clustered_global = pi[min_clustered_global];
+    sum += T(pi[q_lo]) * pi_y - T(pi[q_hi]) * pi_min_clustered_global;
+    sum -= T(b - 2) * (pi_y - pi_min_clustered_global);
+  }
 
-    if (emit)
-    {
-      uint64_t pi_min_clustered_global = pi[min_clustered_global];
-      sum += T(pi_q_lo) * pi_y - T(pi_q_hi) * pi_min_clustered_global;
-      sum -= T(b - 2) * (pi_y - pi_min_clustered_global);
-    }
-
-    // Reflected leaves occupy the contiguous ]pi_conj_lo, pi_conj_hi].
-    pi_conj_lo = max(pi_q_lo, pi_min_m);
-    pi_conj_hi = max(min(pi_q_hi, pi_min_clustered), pi_conj_lo);
+  // Reflected leaves occupy the contiguous ]pi_conj_lo, pi_conj_hi].
+  if (min_clustered_global < max_clustered_global &&
+      segmentedPi.low() < max_clustered_global &&
+      segmentedPi.high() > min_clustered_global + 1)
+  {
+    uint64_t q_lo = fast_div64(xp, max_clustered_global);
+    uint64_t q_hi = fast_div64(xp, min_clustered_global + 1);
+    pi_conj_lo = max(pi[q_lo], pi_min_m);
+    pi_conj_hi = min(pi[q_hi], pi_min_clustered);
+    pi_conj_hi = max(pi_conj_hi, pi_conj_lo);
   }
 
   // Sparse leaves below the reflected sub-range.

--- a/src/gourdon/AC.cpp
+++ b/src/gourdon/AC.cpp
@@ -185,7 +185,7 @@ T C2(T xlow,
   uint64_t max_m = min3(xlow / prime, xp / prime, y);
   T min_m128 = max3(xhigh / prime, xp / (prime * prime), prime);
   uint64_t min_m = min(min_m128, max_m);
-  uint64_t i = pi[max_m];
+  uint64_t pi_max_m = pi[max_m];
   uint64_t pi_min_m = pi[min_m];
   uint64_t sqrt_xp = (uint64_t) isqrt(xp);
   uint64_t min_clustered = in_between(min_m, sqrt_xp, max_m);
@@ -199,8 +199,8 @@ T C2(T xlow,
   // The reflected terms are accumulated by the sparse loops below,
   // possibly in other segments. All contributions use the existing
   // OpenMP reduction, hence no synchronization is needed.
-  if (i > pi_min_clustered &&
-      i == pi_y)
+  if (pi_max_m > pi_min_clustered &&
+      pi_max_m == pi_y)
   {
     uint64_t pi_q_lo = pi[fast_div64(xp, max_clustered_global)];
     uint64_t pi_q_hi = pi[fast_div64(xp, min_clustered_global + 1)];
@@ -212,7 +212,7 @@ T C2(T xlow,
            (pi_y - pi_min_clustered_global);
   }
 
-  i = pi_min_clustered;
+  uint64_t i = pi_min_clustered;
 
   if (segmentedPi.low() > min_clustered_global &&
       segmentedPi.high() <= max_clustered_global)
@@ -609,7 +609,7 @@ T C2_64(T xlow,
   uint64_t max_m = min3(xlow / prime, xp / prime, y);
   T min_m128 = max3(xhigh / prime, xp / (prime * prime), prime);
   uint64_t min_m = min(min_m128, max_m);
-  uint64_t i = pi[max_m];
+  uint64_t pi_max_m = pi[max_m];
   uint64_t pi_min_m = pi[min_m];
   uint64_t sqrt_xp = isqrt(xp);
   uint64_t min_clustered = in_between(min_m, sqrt_xp, max_m);
@@ -623,8 +623,8 @@ T C2_64(T xlow,
   // The reflected terms are accumulated by the sparse loops below,
   // possibly in other segments. All contributions use the existing
   // OpenMP reduction, hence no synchronization is needed.
-  if (i > pi_min_clustered &&
-      i == pi_y)
+  if (pi_max_m > pi_min_clustered &&
+      pi_max_m == pi_y)
   {
     uint64_t pi_q_lo = pi[fast_div64(xp, max_clustered_global)];
     uint64_t pi_q_hi = pi[fast_div64(xp, min_clustered_global + 1)];
@@ -636,7 +636,7 @@ T C2_64(T xlow,
            (pi_y - pi_min_clustered_global);
   }
 
-  i = pi_min_clustered;
+  uint64_t i = pi_min_clustered;
 
   if (segmentedPi.low() > min_clustered_global &&
       segmentedPi.high() <= max_clustered_global)
@@ -720,7 +720,7 @@ T C2_128(T xlow,
   uint64_t max_m = min3(xlow / prime, xp / prime, y);
   T min_m128 = max3(xhigh / prime, xp / (prime * prime), prime);
   uint64_t min_m = min(min_m128, max_m);
-  uint64_t i = pi[max_m];
+  uint64_t pi_max_m = pi[max_m];
   uint64_t pi_min_m = pi[min_m];
   uint64_t sqrt_xp = (uint64_t) isqrt(xp);
   uint64_t min_clustered = in_between(min_m, sqrt_xp, max_m);
@@ -734,8 +734,8 @@ T C2_128(T xlow,
   // The reflected terms are accumulated by the sparse loops below,
   // possibly in other segments. All contributions use the existing
   // OpenMP reduction, hence no synchronization is needed.
-  if (i > pi_min_clustered &&
-      i == pi_y)
+  if (pi_max_m > pi_min_clustered &&
+      pi_max_m == pi_y)
   {
     uint64_t pi_q_lo = pi[fast_div64(xp, max_clustered_global)];
     uint64_t pi_q_hi = pi[fast_div64(xp, min_clustered_global + 1)];
@@ -747,7 +747,7 @@ T C2_128(T xlow,
            (pi_y - pi_min_clustered_global);
   }
 
-  i = pi_min_clustered;
+  uint64_t i = pi_min_clustered;
 
   if (segmentedPi.low() > min_clustered_global &&
       segmentedPi.high() <= max_clustered_global)

--- a/src/gourdon/AC.cpp
+++ b/src/gourdon/AC.cpp
@@ -183,89 +183,69 @@ T C2(T xlow,
 
   uint64_t prime = primes[b];
   uint64_t max_m = min3(xlow / prime, xp / prime, y);
-  T min_m128 = max3(xhigh / prime, xp / (prime * prime), prime);
-  uint64_t min_m = min(min_m128, max_m);
+  uint64_t min_m = min(max3(xhigh / prime, xp / (prime * prime), prime), max_m);
   uint64_t pi_max_m = pi[max_m];
   uint64_t pi_min_m = pi[min_m];
   uint64_t sqrt_xp = (uint64_t) isqrt(xp);
-  uint64_t min_clustered = in_between(min_m, sqrt_xp, max_m);
-  uint64_t pi_min_clustered = pi[min_clustered];
-  uint64_t min_clustered_global = min(
-      max3(xp / (prime * prime), prime, sqrt_xp), y);
+  uint64_t pi_min_clustered = pi[in_between(min_m, sqrt_xp, max_m)];
+  uint64_t min_clustered_global = min(max3(xp / (prime * prime), prime, sqrt_xp), y);
 
-  // For fixed p, ]min_clustered_global, max_clustered_global] is
-  // the complete clustered interval. Emit its boundary correction
-  // once, in the unique segment containing max_clustered_global.
-  // The reflected terms are accumulated by the sparse loops below,
-  // possibly in other segments. All contributions use the existing
-  // OpenMP reduction, hence no synchronization is needed.
-  if (pi_max_m > pi_min_clustered &&
-      pi_max_m == pi_y)
+  uint64_t i = pi_min_clustered;
+  uint64_t pi_conj_lo = pi_min_m;
+  uint64_t pi_conj_hi = pi_min_m;
+
+  // For fixed p, ]min_clustered_global, max_clustered_global] is the
+  // complete clustered interval. Gourdon's inversion equality replaces
+  // its whole contribution by a one-time boundary correction plus a sum
+  // of reflected leaves pi(xp / r). The boundary correction is emitted
+  // once, in the unique segment containing max_clustered_global. The
+  // reflected leaves are the sparse leaves whose xpq lies in the
+  // clustered interval; they are counted a second time by the sparse
+  // loops below, here and in the other segments overlapping the
+  // interval. All contributions enter the existing OpenMP reduction.
+  bool emit = pi_max_m == pi_y && pi_max_m > pi_min_clustered;
+  bool overlap = min_clustered_global < max_clustered_global &&
+                 segmentedPi.low() < max_clustered_global &&
+                 segmentedPi.high() > min_clustered_global + 1;
+
+  if (emit || overlap)
   {
     uint64_t q_lo = fast_div64(xp, max_clustered_global);
     uint64_t q_hi = fast_div64(xp, min_clustered_global + 1);
-    uint64_t pi_min_clustered_global = pi[min_clustered_global];
+    uint64_t pi_q_lo = pi[q_lo];
+    uint64_t pi_q_hi = pi[q_hi];
 
-    sum += T(pi[q_lo]) * pi_y
-         - T(pi[q_hi]) * pi_min_clustered_global;
-    sum -= T(b - 2) *
-           (pi_y - pi_min_clustered_global);
+    if (emit)
+    {
+      uint64_t pi_min_clustered_global = pi[min_clustered_global];
+      sum += T(pi_q_lo) * pi_y - T(pi_q_hi) * pi_min_clustered_global;
+      sum -= T(b - 2) * (pi_y - pi_min_clustered_global);
+    }
+
+    // Reflected leaves occupy the contiguous ]pi_conj_lo, pi_conj_hi].
+    pi_conj_lo = max(pi_q_lo, pi_min_m);
+    pi_conj_hi = max(min(pi_q_hi, pi_min_clustered), pi_conj_lo);
   }
 
-  uint64_t i = pi_min_clustered;
-
-  if (segmentedPi.low() > min_clustered_global &&
-      segmentedPi.high() <= max_clustered_global)
+  // Sparse leaves above the reflected sub-range.
+  for (; i > pi_conj_hi; i--)
   {
-    // Every sparse leaf in this segment is also reflected.
-    for (; i > pi_min_m; i--)
-    {
-      uint64_t xpq = fast_div64(xp, primes[i]);
-      sum += segmentedPi[xpq] * 2 - b + 2;
-    }
+    uint64_t xpq = fast_div64(xp, primes[i]);
+    sum += segmentedPi[xpq] - b + 2;
   }
-  else if (min_clustered_global >= max_clustered_global ||
-           segmentedPi.high() <= min_clustered_global + 1 ||
-           segmentedPi.low() >= max_clustered_global)
+
+  // Reflected leaves: counted once as a sparse leaf, once as a conjugate.
+  for (; i > pi_conj_lo; i--)
   {
-    // This segment has no reflected terms.
-    for (; i > pi_min_m; i--)
-    {
-      uint64_t xpq = fast_div64(xp, primes[i]);
-      sum += segmentedPi[xpq] - b + 2;
-    }
+    uint64_t xpq = fast_div64(xp, primes[i]);
+    sum += segmentedPi[xpq] * 2 - b + 2;
   }
-  else
+
+  // Sparse leaves below the reflected sub-range.
+  for (; i > pi_min_m; i--)
   {
-    // Only segments crossing a clustered endpoint reach this path.
-    // Since xp / primes[i] increases as i decreases, the reflected
-    // leaves form one contiguous prime-index interval.
-    uint64_t pi_conjugate_lo = max(
-        pi[fast_div64(xp, max_clustered_global)], pi_min_m);
-    uint64_t pi_conjugate_hi = max(
-        pi[fast_div64(xp, min_clustered_global + 1)],
-        pi_conjugate_lo);
-
-    // Sparse leaves before the reflected interval.
-    for (; i > pi_conjugate_hi; i--)
-    {
-      uint64_t xpq = fast_div64(xp, primes[i]);
-      sum += segmentedPi[xpq] - b + 2;
-    }
-
-    // Every leaf in this interval is also reflected.
-    for (; i > pi_conjugate_lo; i--)
-    {
-      uint64_t xpq = fast_div64(xp, primes[i]);
-      sum += segmentedPi[xpq] * 2 - b + 2;
-    }
-
-    // Sparse leaves after the reflected interval.
-    for (; i > pi_min_m; i--)
-    {
-      uint64_t xpq = fast_div64(xp, primes[i]);
-      sum += segmentedPi[xpq] - b + 2;
-    }
+    uint64_t xpq = fast_div64(xp, primes[i]);
+    sum += segmentedPi[xpq] - b + 2;
   }
 
   return sum;
@@ -607,89 +587,69 @@ T C2_64(T xlow,
   T sum = 0;
 
   uint64_t max_m = min3(xlow / prime, xp / prime, y);
-  T min_m128 = max3(xhigh / prime, xp / (prime * prime), prime);
-  uint64_t min_m = min(min_m128, max_m);
+  uint64_t min_m = min(max3(xhigh / prime, xp / (prime * prime), prime), max_m);
   uint64_t pi_max_m = pi[max_m];
   uint64_t pi_min_m = pi[min_m];
   uint64_t sqrt_xp = isqrt(xp);
-  uint64_t min_clustered = in_between(min_m, sqrt_xp, max_m);
-  uint64_t pi_min_clustered = pi[min_clustered];
-  uint64_t min_clustered_global = min(
-      max3(xp / (prime * prime), prime, sqrt_xp), y);
+  uint64_t pi_min_clustered = pi[in_between(min_m, sqrt_xp, max_m)];
+  uint64_t min_clustered_global = min(max3(xp / (prime * prime), prime, sqrt_xp), y);
 
-  // For fixed p, ]min_clustered_global, max_clustered_global] is
-  // the complete clustered interval. Emit its boundary correction
-  // once, in the unique segment containing max_clustered_global.
-  // The reflected terms are accumulated by the sparse loops below,
-  // possibly in other segments. All contributions use the existing
-  // OpenMP reduction, hence no synchronization is needed.
-  if (pi_max_m > pi_min_clustered &&
-      pi_max_m == pi_y)
+  uint64_t i = pi_min_clustered;
+  uint64_t pi_conj_lo = pi_min_m;
+  uint64_t pi_conj_hi = pi_min_m;
+
+  // For fixed p, ]min_clustered_global, max_clustered_global] is the
+  // complete clustered interval. Gourdon's inversion equality replaces
+  // its whole contribution by a one-time boundary correction plus a sum
+  // of reflected leaves pi(xp / r). The boundary correction is emitted
+  // once, in the unique segment containing max_clustered_global. The
+  // reflected leaves are the sparse leaves whose xpq lies in the
+  // clustered interval; they are counted a second time by the sparse
+  // loops below, here and in the other segments overlapping the
+  // interval. All contributions enter the existing OpenMP reduction.
+  bool emit = pi_max_m == pi_y && pi_max_m > pi_min_clustered;
+  bool overlap = min_clustered_global < max_clustered_global &&
+                 segmentedPi.low() < max_clustered_global &&
+                 segmentedPi.high() > min_clustered_global + 1;
+
+  if (emit || overlap)
   {
     uint64_t q_lo = fast_div64(xp, max_clustered_global);
     uint64_t q_hi = fast_div64(xp, min_clustered_global + 1);
-    uint64_t pi_min_clustered_global = pi[min_clustered_global];
+    uint64_t pi_q_lo = pi[q_lo];
+    uint64_t pi_q_hi = pi[q_hi];
 
-    sum += T(pi[q_lo]) * pi_y
-         - T(pi[q_hi]) * pi_min_clustered_global;
-    sum -= T(b - 2) *
-           (pi_y - pi_min_clustered_global);
+    if (emit)
+    {
+      uint64_t pi_min_clustered_global = pi[min_clustered_global];
+      sum += T(pi_q_lo) * pi_y - T(pi_q_hi) * pi_min_clustered_global;
+      sum -= T(b - 2) * (pi_y - pi_min_clustered_global);
+    }
+
+    // Reflected leaves occupy the contiguous ]pi_conj_lo, pi_conj_hi].
+    pi_conj_lo = max(pi_q_lo, pi_min_m);
+    pi_conj_hi = max(min(pi_q_hi, pi_min_clustered), pi_conj_lo);
   }
 
-  uint64_t i = pi_min_clustered;
-
-  if (segmentedPi.low() > min_clustered_global &&
-      segmentedPi.high() <= max_clustered_global)
+  // Sparse leaves above the reflected sub-range.
+  for (; i > pi_conj_hi; i--)
   {
-    // Every sparse leaf in this segment is also reflected.
-    for (; i > pi_min_m; i--)
-    {
-      uint64_t xpq = xp / primes[i];
-      sum += segmentedPi[xpq] * 2 - b + 2;
-    }
+    uint64_t xpq = xp / primes[i];
+    sum += segmentedPi[xpq] - b + 2;
   }
-  else if (min_clustered_global >= max_clustered_global ||
-           segmentedPi.high() <= min_clustered_global + 1 ||
-           segmentedPi.low() >= max_clustered_global)
+
+  // Reflected leaves: counted once as a sparse leaf, once as a conjugate.
+  for (; i > pi_conj_lo; i--)
   {
-    // This segment has no reflected terms.
-    for (; i > pi_min_m; i--)
-    {
-      uint64_t xpq = xp / primes[i];
-      sum += segmentedPi[xpq] - b + 2;
-    }
+    uint64_t xpq = xp / primes[i];
+    sum += segmentedPi[xpq] * 2 - b + 2;
   }
-  else
+
+  // Sparse leaves below the reflected sub-range.
+  for (; i > pi_min_m; i--)
   {
-    // Only segments crossing a clustered endpoint reach this path.
-    // Since xp / primes[i] increases as i decreases, the reflected
-    // leaves form one contiguous prime-index interval.
-    uint64_t pi_conjugate_lo = max(
-        pi[fast_div64(xp, max_clustered_global)], pi_min_m);
-    uint64_t pi_conjugate_hi = max(
-        pi[fast_div64(xp, min_clustered_global + 1)],
-        pi_conjugate_lo);
-
-    // Sparse leaves before the reflected interval.
-    for (; i > pi_conjugate_hi; i--)
-    {
-      uint64_t xpq = xp / primes[i];
-      sum += segmentedPi[xpq] - b + 2;
-    }
-
-    // Every leaf in this interval is also reflected.
-    for (; i > pi_conjugate_lo; i--)
-    {
-      uint64_t xpq = xp / primes[i];
-      sum += segmentedPi[xpq] * 2 - b + 2;
-    }
-
-    // Sparse leaves after the reflected interval.
-    for (; i > pi_min_m; i--)
-    {
-      uint64_t xpq = xp / primes[i];
-      sum += segmentedPi[xpq] - b + 2;
-    }
+    uint64_t xpq = xp / primes[i];
+    sum += segmentedPi[xpq] - b + 2;
   }
 
   return sum;
@@ -718,89 +678,69 @@ T C2_128(T xlow,
 
   uint64_t prime = primes[b];
   uint64_t max_m = min3(xlow / prime, xp / prime, y);
-  T min_m128 = max3(xhigh / prime, xp / (prime * prime), prime);
-  uint64_t min_m = min(min_m128, max_m);
+  uint64_t min_m = min(max3(xhigh / prime, xp / (prime * prime), prime), max_m);
   uint64_t pi_max_m = pi[max_m];
   uint64_t pi_min_m = pi[min_m];
   uint64_t sqrt_xp = (uint64_t) isqrt(xp);
-  uint64_t min_clustered = in_between(min_m, sqrt_xp, max_m);
-  uint64_t pi_min_clustered = pi[min_clustered];
-  uint64_t min_clustered_global = min(
-      max3(xp / (prime * prime), prime, sqrt_xp), y);
+  uint64_t pi_min_clustered = pi[in_between(min_m, sqrt_xp, max_m)];
+  uint64_t min_clustered_global = min(max3(xp / (prime * prime), prime, sqrt_xp), y);
 
-  // For fixed p, ]min_clustered_global, max_clustered_global] is
-  // the complete clustered interval. Emit its boundary correction
-  // once, in the unique segment containing max_clustered_global.
-  // The reflected terms are accumulated by the sparse loops below,
-  // possibly in other segments. All contributions use the existing
-  // OpenMP reduction, hence no synchronization is needed.
-  if (pi_max_m > pi_min_clustered &&
-      pi_max_m == pi_y)
+  uint64_t i = pi_min_clustered;
+  uint64_t pi_conj_lo = pi_min_m;
+  uint64_t pi_conj_hi = pi_min_m;
+
+  // For fixed p, ]min_clustered_global, max_clustered_global] is the
+  // complete clustered interval. Gourdon's inversion equality replaces
+  // its whole contribution by a one-time boundary correction plus a sum
+  // of reflected leaves pi(xp / r). The boundary correction is emitted
+  // once, in the unique segment containing max_clustered_global. The
+  // reflected leaves are the sparse leaves whose xpq lies in the
+  // clustered interval; they are counted a second time by the sparse
+  // loops below, here and in the other segments overlapping the
+  // interval. All contributions enter the existing OpenMP reduction.
+  bool emit = pi_max_m == pi_y && pi_max_m > pi_min_clustered;
+  bool overlap = min_clustered_global < max_clustered_global &&
+                 segmentedPi.low() < max_clustered_global &&
+                 segmentedPi.high() > min_clustered_global + 1;
+
+  if (emit || overlap)
   {
     uint64_t q_lo = fast_div64(xp, max_clustered_global);
     uint64_t q_hi = fast_div64(xp, min_clustered_global + 1);
-    uint64_t pi_min_clustered_global = pi[min_clustered_global];
+    uint64_t pi_q_lo = pi[q_lo];
+    uint64_t pi_q_hi = pi[q_hi];
 
-    sum += T(pi[q_lo]) * pi_y
-         - T(pi[q_hi]) * pi_min_clustered_global;
-    sum -= T(b - 2) *
-           (pi_y - pi_min_clustered_global);
+    if (emit)
+    {
+      uint64_t pi_min_clustered_global = pi[min_clustered_global];
+      sum += T(pi_q_lo) * pi_y - T(pi_q_hi) * pi_min_clustered_global;
+      sum -= T(b - 2) * (pi_y - pi_min_clustered_global);
+    }
+
+    // Reflected leaves occupy the contiguous ]pi_conj_lo, pi_conj_hi].
+    pi_conj_lo = max(pi_q_lo, pi_min_m);
+    pi_conj_hi = max(min(pi_q_hi, pi_min_clustered), pi_conj_lo);
   }
 
-  uint64_t i = pi_min_clustered;
-
-  if (segmentedPi.low() > min_clustered_global &&
-      segmentedPi.high() <= max_clustered_global)
+  // Sparse leaves above the reflected sub-range.
+  for (; i > pi_conj_hi; i--)
   {
-    // Every sparse leaf in this segment is also reflected.
-    for (; i > pi_min_m; i--)
-    {
-      uint64_t xpq = fast_div64(xp, primes[i]);
-      sum += segmentedPi[xpq] * 2 - b + 2;
-    }
+    uint64_t xpq = fast_div64(xp, primes[i]);
+    sum += segmentedPi[xpq] - b + 2;
   }
-  else if (min_clustered_global >= max_clustered_global ||
-           segmentedPi.high() <= min_clustered_global + 1 ||
-           segmentedPi.low() >= max_clustered_global)
+
+  // Reflected leaves: counted once as a sparse leaf, once as a conjugate.
+  for (; i > pi_conj_lo; i--)
   {
-    // This segment has no reflected terms.
-    for (; i > pi_min_m; i--)
-    {
-      uint64_t xpq = fast_div64(xp, primes[i]);
-      sum += segmentedPi[xpq] - b + 2;
-    }
+    uint64_t xpq = fast_div64(xp, primes[i]);
+    sum += segmentedPi[xpq] * 2 - b + 2;
   }
-  else
+
+  // Sparse leaves below the reflected sub-range.
+  for (; i > pi_min_m; i--)
   {
-    // Only segments crossing a clustered endpoint reach this path.
-    // Since xp / primes[i] increases as i decreases, the reflected
-    // leaves form one contiguous prime-index interval.
-    uint64_t pi_conjugate_lo = max(
-        pi[fast_div64(xp, max_clustered_global)], pi_min_m);
-    uint64_t pi_conjugate_hi = max(
-        pi[fast_div64(xp, min_clustered_global + 1)],
-        pi_conjugate_lo);
-
-    // Sparse leaves before the reflected interval.
-    for (; i > pi_conjugate_hi; i--)
-    {
-      uint64_t xpq = fast_div64(xp, primes[i]);
-      sum += segmentedPi[xpq] - b + 2;
-    }
-
-    // Every leaf in this interval is also reflected.
-    for (; i > pi_conjugate_lo; i--)
-    {
-      uint64_t xpq = fast_div64(xp, primes[i]);
-      sum += segmentedPi[xpq] * 2 - b + 2;
-    }
-
-    // Sparse leaves after the reflected interval.
-    for (; i > pi_min_m; i--)
-    {
-      uint64_t xpq = fast_div64(xp, primes[i]);
-      sum += segmentedPi[xpq] - b + 2;
-    }
+    uint64_t xpq = fast_div64(xp, primes[i]);
+    sum += segmentedPi[xpq] - b + 2;
   }
 
   return sum;

--- a/src/gourdon/AC.cpp
+++ b/src/gourdon/AC.cpp
@@ -219,16 +219,9 @@ T C2(T xlow,
 
   uint64_t segment_low = (uint64_t) segmentedPi.low();
   uint64_t segment_high = (uint64_t) segmentedPi.high();
-  bool all_conjugate =
-      has_clustered &&
+  if (has_clustered &&
       segment_low > min_clustered_global &&
-      segment_high <= max_clustered_global;
-  bool overlaps_conjugate =
-      has_clustered &&
-      segment_high > min_clustered_global + 1 &&
-      segment_low < max_clustered_global;
-
-  if (all_conjugate)
+      segment_high <= max_clustered_global)
   {
     // Every sparse leaf in this segment is also reflected.
     for (; i > pi_min_m; i--)
@@ -237,7 +230,9 @@ T C2(T xlow,
       sum += segmentedPi[xpq] * 2 - b + 2;
     }
   }
-  else if (!overlaps_conjugate)
+  else if (!has_clustered ||
+           segment_high <= min_clustered_global + 1 ||
+           segment_low >= max_clustered_global)
   {
     // This segment has no reflected terms.
     for (; i > pi_min_m; i--)
@@ -654,16 +649,9 @@ T C2_64(T xlow,
 
   uint64_t segment_low = (uint64_t) segmentedPi.low();
   uint64_t segment_high = (uint64_t) segmentedPi.high();
-  bool all_conjugate =
-      has_clustered &&
+  if (has_clustered &&
       segment_low > min_clustered_global &&
-      segment_high <= max_clustered_global;
-  bool overlaps_conjugate =
-      has_clustered &&
-      segment_high > min_clustered_global + 1 &&
-      segment_low < max_clustered_global;
-
-  if (all_conjugate)
+      segment_high <= max_clustered_global)
   {
     // Every sparse leaf in this segment is also reflected.
     for (; i > pi_min_m; i--)
@@ -672,7 +660,9 @@ T C2_64(T xlow,
       sum += segmentedPi[xpq] * 2 - b + 2;
     }
   }
-  else if (!overlaps_conjugate)
+  else if (!has_clustered ||
+           segment_high <= min_clustered_global + 1 ||
+           segment_low >= max_clustered_global)
   {
     // This segment has no reflected terms.
     for (; i > pi_min_m; i--)
@@ -776,16 +766,9 @@ T C2_128(T xlow,
 
   uint64_t segment_low = (uint64_t) segmentedPi.low();
   uint64_t segment_high = (uint64_t) segmentedPi.high();
-  bool all_conjugate =
-      has_clustered &&
+  if (has_clustered &&
       segment_low > min_clustered_global &&
-      segment_high <= max_clustered_global;
-  bool overlaps_conjugate =
-      has_clustered &&
-      segment_high > min_clustered_global + 1 &&
-      segment_low < max_clustered_global;
-
-  if (all_conjugate)
+      segment_high <= max_clustered_global)
   {
     // Every sparse leaf in this segment is also reflected.
     for (; i > pi_min_m; i--)
@@ -794,7 +777,9 @@ T C2_128(T xlow,
       sum += segmentedPi[xpq] * 2 - b + 2;
     }
   }
-  else if (!overlaps_conjugate)
+  else if (!has_clustered ||
+           segment_high <= min_clustered_global + 1 ||
+           segment_low >= max_clustered_global)
   {
     // This segment has no reflected terms.
     for (; i > pi_min_m; i--)

--- a/src/gourdon/AC.cpp
+++ b/src/gourdon/AC.cpp
@@ -174,7 +174,7 @@ T C2(T xlow,
      uint64_t y,
      uint64_t b,
      uint64_t pi_y,
-     uint64_t max_y_prime,
+     uint64_t max_clustered_global,
      const Primes& primes,
      const PiTable& pi,
      const SegmentedPiTable& segmentedPi)
@@ -190,9 +190,8 @@ T C2(T xlow,
   uint64_t sqrt_xp = (uint64_t) isqrt(xp);
   uint64_t min_clustered = in_between(min_m, sqrt_xp, max_m);
   uint64_t pi_min_clustered = pi[min_clustered];
-  XP min_clustered128 = max3(xp / (prime * prime), prime, sqrt_xp);
-  uint64_t min_clustered_global = min(min_clustered128, y);
-  uint64_t max_clustered_global = max_y_prime;
+  uint64_t min_clustered_global = min(
+      max3(xp / (prime * prime), prime, sqrt_xp), y);
   bool has_clustered = max_clustered_global > min_clustered_global;
 
   // For fixed p, ]min_clustered_global, max_clustered_global] is
@@ -205,10 +204,8 @@ T C2(T xlow,
   {
     if (has_clustered && i == pi_y)
     {
-      uint64_t q_lo = fast_div64(xp, max_clustered_global);
-      uint64_t q_hi = fast_div64(xp, min_clustered_global + 1);
-      uint64_t pi_q_lo = pi[q_lo];
-      uint64_t pi_q_hi = pi[q_hi];
+      uint64_t pi_q_lo = pi[fast_div64(xp, max_clustered_global)];
+      uint64_t pi_q_hi = pi[fast_div64(xp, min_clustered_global + 1)];
       uint64_t pi_min_clustered_global = pi[min_clustered_global];
 
       sum += T(pi_q_lo) * pi_y
@@ -254,10 +251,11 @@ T C2(T xlow,
     // Only segments crossing a clustered endpoint reach this path.
     // Since xp / primes[i] increases as i decreases, the reflected
     // leaves form one contiguous prime-index interval.
-    uint64_t q_lo = fast_div64(xp, max_clustered_global);
-    uint64_t q_hi = fast_div64(xp, min_clustered_global + 1);
-    uint64_t pi_conjugate_lo = max(pi[q_lo], pi_min_m);
-    uint64_t pi_conjugate_hi = max(pi[q_hi], pi_conjugate_lo);
+    uint64_t pi_conjugate_lo = max(
+        pi[fast_div64(xp, max_clustered_global)], pi_min_m);
+    uint64_t pi_conjugate_hi = max(
+        pi[fast_div64(xp, min_clustered_global + 1)],
+        pi_conjugate_lo);
 
     // Sparse leaves before the reflected interval.
     for (; i > pi_conjugate_hi; i--)
@@ -318,7 +316,7 @@ T AC_OpenMP(T x,
   PiTable pi(max(z, max_a_prime), threads);
 
   uint64_t pi_y = pi[y];
-  uint64_t max_y_prime = pi_y ? primes[pi_y] : 0;
+  uint64_t max_clustered_global = pi_y ? primes[pi_y] : 0;
   int64_t pi_sqrtz = pi[isqrt(z)];
   int64_t pi_root3_xy = pi[iroot<3>(xy)];
   int64_t pi_root3_xz = pi[iroot<3>(xz)];
@@ -404,9 +402,9 @@ T AC_OpenMP(T x,
           T xp = x / primes[b];
 
           if (xp <= pstd::numeric_limits<uint64_t>::max())
-            sum += C2(xlow, xhigh, uint64_t(xp), y, b, pi_y, max_y_prime, primes, pi, segmentedPi);
+            sum += C2(xlow, xhigh, uint64_t(xp), y, b, pi_y, max_clustered_global, primes, pi, segmentedPi);
           else
-            sum += C2(xlow, xhigh, xp, y, b, pi_y, max_y_prime, primes, pi, segmentedPi);
+            sum += C2(xlow, xhigh, xp, y, b, pi_y, max_clustered_global, primes, pi, segmentedPi);
         }
 
         // A formula: pi[x_star] < b <= pi[x13]
@@ -611,7 +609,7 @@ T C2_64(T xlow,
         uint64_t y,
         uint64_t b,
         uint64_t pi_y,
-        uint64_t max_y_prime,
+        uint64_t max_clustered_global,
         uint64_t prime,
         const LibdividePrimes& primes,
         const PiTable& pi,
@@ -627,9 +625,8 @@ T C2_64(T xlow,
   uint64_t sqrt_xp = isqrt(xp);
   uint64_t min_clustered = in_between(min_m, sqrt_xp, max_m);
   uint64_t pi_min_clustered = pi[min_clustered];
-  uint64_t min_clustered128 = max3(xp / (prime * prime), prime, sqrt_xp);
-  uint64_t min_clustered_global = min(min_clustered128, y);
-  uint64_t max_clustered_global = max_y_prime;
+  uint64_t min_clustered_global = min(
+      max3(xp / (prime * prime), prime, sqrt_xp), y);
   bool has_clustered = max_clustered_global > min_clustered_global;
 
   // For fixed p, ]min_clustered_global, max_clustered_global] is
@@ -642,10 +639,8 @@ T C2_64(T xlow,
   {
     if (has_clustered && i == pi_y)
     {
-      uint64_t q_lo = fast_div64(xp, max_clustered_global);
-      uint64_t q_hi = fast_div64(xp, min_clustered_global + 1);
-      uint64_t pi_q_lo = pi[q_lo];
-      uint64_t pi_q_hi = pi[q_hi];
+      uint64_t pi_q_lo = pi[fast_div64(xp, max_clustered_global)];
+      uint64_t pi_q_hi = pi[fast_div64(xp, min_clustered_global + 1)];
       uint64_t pi_min_clustered_global = pi[min_clustered_global];
 
       sum += T(pi_q_lo) * pi_y
@@ -691,10 +686,11 @@ T C2_64(T xlow,
     // Only segments crossing a clustered endpoint reach this path.
     // Since xp / primes[i] increases as i decreases, the reflected
     // leaves form one contiguous prime-index interval.
-    uint64_t q_lo = fast_div64(xp, max_clustered_global);
-    uint64_t q_hi = fast_div64(xp, min_clustered_global + 1);
-    uint64_t pi_conjugate_lo = max(pi[q_lo], pi_min_m);
-    uint64_t pi_conjugate_hi = max(pi[q_hi], pi_conjugate_lo);
+    uint64_t pi_conjugate_lo = max(
+        pi[fast_div64(xp, max_clustered_global)], pi_min_m);
+    uint64_t pi_conjugate_hi = max(
+        pi[fast_div64(xp, min_clustered_global + 1)],
+        pi_conjugate_lo);
 
     // Sparse leaves before the reflected interval.
     for (; i > pi_conjugate_hi; i--)
@@ -735,7 +731,7 @@ T C2_128(T xlow,
          uint64_t y,
          uint64_t b,
          uint64_t pi_y,
-         uint64_t max_y_prime,
+         uint64_t max_clustered_global,
          const Primes& primes,
          const PiTable& pi,
          const SegmentedPiTable& segmentedPi)
@@ -751,9 +747,8 @@ T C2_128(T xlow,
   uint64_t sqrt_xp = (uint64_t) isqrt(xp);
   uint64_t min_clustered = in_between(min_m, sqrt_xp, max_m);
   uint64_t pi_min_clustered = pi[min_clustered];
-  T min_clustered128 = max3(xp / (prime * prime), prime, sqrt_xp);
-  uint64_t min_clustered_global = min(min_clustered128, y);
-  uint64_t max_clustered_global = max_y_prime;
+  uint64_t min_clustered_global = min(
+      max3(xp / (prime * prime), prime, sqrt_xp), y);
   bool has_clustered = max_clustered_global > min_clustered_global;
 
   // For fixed p, ]min_clustered_global, max_clustered_global] is
@@ -766,10 +761,8 @@ T C2_128(T xlow,
   {
     if (has_clustered && i == pi_y)
     {
-      uint64_t q_lo = fast_div64(xp, max_clustered_global);
-      uint64_t q_hi = fast_div64(xp, min_clustered_global + 1);
-      uint64_t pi_q_lo = pi[q_lo];
-      uint64_t pi_q_hi = pi[q_hi];
+      uint64_t pi_q_lo = pi[fast_div64(xp, max_clustered_global)];
+      uint64_t pi_q_hi = pi[fast_div64(xp, min_clustered_global + 1)];
       uint64_t pi_min_clustered_global = pi[min_clustered_global];
 
       sum += T(pi_q_lo) * pi_y
@@ -815,10 +808,11 @@ T C2_128(T xlow,
     // Only segments crossing a clustered endpoint reach this path.
     // Since xp / primes[i] increases as i decreases, the reflected
     // leaves form one contiguous prime-index interval.
-    uint64_t q_lo = fast_div64(xp, max_clustered_global);
-    uint64_t q_hi = fast_div64(xp, min_clustered_global + 1);
-    uint64_t pi_conjugate_lo = max(pi[q_lo], pi_min_m);
-    uint64_t pi_conjugate_hi = max(pi[q_hi], pi_conjugate_lo);
+    uint64_t pi_conjugate_lo = max(
+        pi[fast_div64(xp, max_clustered_global)], pi_min_m);
+    uint64_t pi_conjugate_hi = max(
+        pi[fast_div64(xp, min_clustered_global + 1)],
+        pi_conjugate_lo);
 
     // Sparse leaves before the reflected interval.
     for (; i > pi_conjugate_hi; i--)
@@ -885,7 +879,7 @@ T AC_OpenMP(T x,
   PiTable pi(max(z, max_a_prime), threads);
 
   uint64_t pi_y = pi[y];
-  uint64_t max_y_prime = pi_y ? primes[pi_y] : 0;
+  uint64_t max_clustered_global = pi_y ? primes[pi_y] : 0;
   int64_t pi_sqrtz = pi[isqrt(z)];
   int64_t pi_root3_xy = pi[iroot<3>(xy)];
   int64_t pi_root3_xz = pi[iroot<3>(xz)];
@@ -972,9 +966,9 @@ T AC_OpenMP(T x,
           T xp = x / prime;
 
           if (xp <= pstd::numeric_limits<uint64_t>::max())
-            sum += C2_64(xlow, xhigh, (uint64_t) xp, y, b, pi_y, max_y_prime, prime, lprimes, pi, segmentedPi);
+            sum += C2_64(xlow, xhigh, (uint64_t) xp, y, b, pi_y, max_clustered_global, prime, lprimes, pi, segmentedPi);
           else
-            sum += C2_128(xlow, xhigh, xp, y, b, pi_y, max_y_prime, primes, pi, segmentedPi);
+            sum += C2_128(xlow, xhigh, xp, y, b, pi_y, max_clustered_global, primes, pi, segmentedPi);
         }
 
         // A formula: pi[x_star] < b <= pi[x13]

--- a/src/gourdon/AC.cpp
+++ b/src/gourdon/AC.cpp
@@ -278,7 +278,7 @@ T AC_OpenMP(T x,
   PiTable pi(max(z, max_a_prime), threads);
 
   uint64_t pi_y = pi[y];
-  uint64_t max_clustered_global = pi_y ? primes[pi_y] : 0;
+  uint64_t max_clustered_global = primes[pi_y];
   int64_t pi_sqrtz = pi[isqrt(z)];
   int64_t pi_root3_xy = pi[iroot<3>(xy)];
   int64_t pi_root3_xz = pi[iroot<3>(xz)];
@@ -765,7 +765,7 @@ T AC_OpenMP(T x,
   PiTable pi(max(z, max_a_prime), threads);
 
   uint64_t pi_y = pi[y];
-  uint64_t max_clustered_global = pi_y ? primes[pi_y] : 0;
+  uint64_t max_clustered_global = primes[pi_y];
   int64_t pi_sqrtz = pi[isqrt(z)];
   int64_t pi_root3_xy = pi[iroot<3>(xy)];
   int64_t pi_root3_xz = pi[iroot<3>(xz)];

--- a/src/gourdon/SegmentedPiTable.hpp
+++ b/src/gourdon/SegmentedPiTable.hpp
@@ -43,23 +43,23 @@ class SegmentedPiTable
 public:
   void init(uint64_t low, uint64_t high, uint64_t limit);
 
-  int64_t low() const
+  uint64_t low() const
   {
     return low_;
   }
 
-  int64_t high() const
+  uint64_t high() const
   {
     return high_;
   }
 
-  static constexpr int64_t numbers_per_byte()
+  static constexpr uint64_t numbers_per_byte()
   {
     return 128 / (sizeof(uint64_t) * 2);
   }
 
   /// Make sure size % 128 == 0
-  static int64_t align_segment_size(uint64_t size)
+  static uint64_t align_segment_size(uint64_t size)
   {
     size = std::max<uint64_t>(128, size);
 
@@ -70,7 +70,7 @@ public:
   }
 
   /// Get number of primes <= x
-  ALWAYS_INLINE int64_t operator[](uint64_t x) const
+  ALWAYS_INLINE uint64_t operator[](uint64_t x) const
   {
     ASSERT(x >= low_);
     ASSERT(x < high_);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -326,7 +326,7 @@ std::pair<double, double> get_alpha_gourdon(maxint_t x)
     // synchronization. The larger alpha_z, the less work there will
     // be in the C1 algorithm. Hence for computations >= 10^23 using
     // an alpha_z > 1 will likely improve performance.
-    alpha_z = 1.5;
+    alpha_z = 1.2;
 
     // alpha_z should be significantly smaller than alpha_y
     alpha_z = in_between(1, alpha_yz / 5, alpha_z);

--- a/test/gourdon/SegmentedPiTable.cpp
+++ b/test/gourdon/SegmentedPiTable.cpp
@@ -62,7 +62,7 @@ int main()
     }
 
     std::cout << "segmentedPi(" << i << ") = " << segmentedPi[i];
-    check(segmentedPi[i] == pi[i]);
+    check(segmentedPi[i] == (uint64_t) pi[i]);
   }
 
   // Check large pi(x) values
@@ -79,7 +79,7 @@ int main()
     }
 
     std::cout << "segmentedPi(" << i << ") = " << segmentedPi[i];
-    check(segmentedPi[i] == pi[i]);
+    check(segmentedPi[i] == (uint64_t) pi[i]);
   }
 
   while (high < limit)
@@ -94,7 +94,7 @@ int main()
   // PiTable can lookup numbers <= limit.
   // SegmentedPiTable can lookup numbers < limit.
   std::cout << "segmentedPi(" << limit-1 << ") = " << segmentedPi[limit-1];
-  check(segmentedPi[limit-1] == pi[limit-1]);
+  check(segmentedPi[limit-1] == (uint64_t) pi[limit-1]);
 
   std::cout << std::endl;
   std::cout << "All tests passed successfully!" << std::endl;


### PR DESCRIPTION
The new algorithm merges the clustered easy leaves with the sparse easy leaves in the C formula of Gourdon's algorithm. Hence completely avoiding having to calculate the clustered easy leaves. This improves the performance of the AC algorithm by up to 10% on my Intel Core Ultra 245k.