### PR TITLE
Add NO_VECTORIZE_LOOP macro

### DIFF
--- a/include/macros.hpp
+++ b/include/macros.hpp
@@ -156,7 +156,7 @@
 /// that execute very few iterations on average.
 #if defined(__clang__)
   #define NO_VECTORIZE_LOOP _Pragma("clang loop vectorize(disable)")
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) && __GNUC__ >= 14
   #define NO_VECTORIZE_LOOP _Pragma("GCC novector")
 #elif defined(_MSC_VER)
   #define NO_VECTORIZE_LOOP __pragma(loop(no_vector))

--- a/include/macros.hpp
+++ b/include/macros.hpp
@@ -142,14 +142,26 @@
 
 /// Unrolling loops that execute very few iterations on average
 /// tends to deteriorate performance due to increased branch
-/// mispredictions. Using the NOUNROLL_LOOP macro we can disable
+/// mispredictions. Using the NO_UNROLL_LOOP macro we can disable
 /// loop unrolling for such loops.
 #if defined(__clang__)
-  #define NOUNROLL_LOOP _Pragma("nounroll")
+  #define NO_UNROLL_LOOP _Pragma("nounroll")
 #elif defined(__GNUC__) && __GNUC__ >= 8
-  #define NOUNROLL_LOOP _Pragma("GCC unroll 0")
+  #define NO_UNROLL_LOOP _Pragma("GCC unroll 0")
 #else
-  #define NOUNROLL_LOOP
+  #define NO_UNROLL_LOOP
+#endif
+
+/// Disable automatic vectorization. Used for loops
+/// that execute very few iterations on average.
+#if defined(__clang__)
+  #define NO_VECTORIZE_LOOP _Pragma("clang loop vectorize(disable)")
+#elif defined(__GNUC__)
+  #define NO_VECTORIZE_LOOP _Pragma("GCC novector")
+#elif defined(_MSC_VER)
+  #define NO_VECTORIZE_LOOP __pragma(loop(no_vector))
+#else
+  #define NO_VECTORIZE_LOOP
 #endif
 
 // Branchfree conditional move instruction:

--- a/src/gourdon/AC.cpp
+++ b/src/gourdon/AC.cpp
@@ -80,7 +80,7 @@ T A(T xlow,
 
   // pq = primes[b] * primes[i]
   // x / pq >= y && low <= x / pq < high
-  NOUNROLL_LOOP
+  NO_UNROLL_LOOP
   for (; i <= max_i1; i++)
   {
     uint64_t xpq = fast_div64(xp, primes[i]);
@@ -103,7 +103,7 @@ T A(T xlow,
 
   // pq = primes[b] * primes[i]
   // x / pq < y && low <= x / pq < high
-  NOUNROLL_LOOP
+  NO_UNROLL_LOOP
   for (; i <= max_i2; i++)
   {
     uint64_t xpq = fast_div64(xp, primes[i]);
@@ -170,7 +170,7 @@ T C1(T xlow,
              (segmentedPi[xpm3] - b + 2);
     }
 
-    NOUNROLL_LOOP
+    NO_UNROLL_LOOP
     for (; i <= max_i; i++)
     {
       uint64_t xpm = fast_div64(xp, primes[i]);
@@ -215,7 +215,7 @@ T C1(T xlow,
                (segmentedPi[xpm3] - b + 2);
       }
 
-      NOUNROLL_LOOP
+      NO_UNROLL_LOOP
       for (; j <= max_j; j++)
       {
         uint64_t xpm = fast_div64(xpq, primes[j]);
@@ -292,7 +292,7 @@ T C2(T xlow,
   }
 
   // Sparse leaves below the reflected range
-  NOUNROLL_LOOP
+  NO_UNROLL_LOOP
   for (; i <= pi_conj_lo; i++)
   {
     uint64_t xpq = fast_div64(xp, primes[i]);
@@ -314,7 +314,7 @@ T C2(T xlow,
            (segmentedPi[xpq3] * 2 - b + 2);
   }
 
-  NOUNROLL_LOOP
+  NO_UNROLL_LOOP
   for (; i <= pi_conj_hi; i++)
   {
     uint64_t xpq = fast_div64(xp, primes[i]);
@@ -336,7 +336,7 @@ T C2(T xlow,
            (segmentedPi[xpq3] - b + 2);
   }
 
-  NOUNROLL_LOOP
+  NO_UNROLL_LOOP
   for (; i <= pi_min_clustered; i++)
   {
     uint64_t xpq = fast_div64(xp, primes[i]);
@@ -540,7 +540,7 @@ T A_64(T xlow,
 
   // pq = primes[b] * primes[i]
   // x / pq >= y && low <= x / pq < high
-  NOUNROLL_LOOP
+  NO_UNROLL_LOOP
   for (; i <= max_i1; i++)
   {
     uint64_t xpq = xp / primes[i];
@@ -563,7 +563,7 @@ T A_64(T xlow,
 
   // pq = primes[b] * primes[i]
   // x / pq < y && low <= x / pq < high
-  NOUNROLL_LOOP
+  NO_UNROLL_LOOP
   for (; i <= max_i2; i++)
   {
     uint64_t xpq = xp / primes[i];
@@ -600,7 +600,7 @@ T A_128(T xlow,
 
   // pq = primes[b] * primes[i]
   // x / pq >= y && low <= x / pq < high
-  NOUNROLL_LOOP
+  NO_UNROLL_LOOP
   for (; i <= max_i1; i++)
   {
     uint64_t xpq = fast_div64(xp, primes[i]);
@@ -623,7 +623,7 @@ T A_128(T xlow,
 
   // pq = primes[b] * primes[i]
   // x / pq < y && low <= x / pq < high
-  NOUNROLL_LOOP
+  NO_UNROLL_LOOP
   for (; i <= max_i2; i++)
   {
     uint64_t xpq = fast_div64(xp, primes[i]);
@@ -692,7 +692,7 @@ T C1_64(T xlow,
              (segmentedPi[xpm3] - b + 2);
     }
 
-    NOUNROLL_LOOP
+    NO_UNROLL_LOOP
     for (; i <= max_i; i++)
     {
       uint64_t xpm = xp / lprimes[i];
@@ -722,7 +722,7 @@ T C1_64(T xlow,
       uint64_t max_j = pi[max_r];
       uint64_t xpq = xp / lprimes[i];
 
-      NOUNROLL_LOOP
+      NO_UNROLL_LOOP
       for (uint64_t j = min_j; j <= max_j; j++)
       {
         uint64_t xpm = xpq / lprimes[j];
@@ -791,7 +791,7 @@ T C1_128(T xlow,
              (segmentedPi[xpm3] - b + 2);
     }
 
-    NOUNROLL_LOOP
+    NO_UNROLL_LOOP
     for (; i <= max_i; i++)
     {
       uint64_t xpm = fast_div64(xp, primes[i]);
@@ -836,7 +836,7 @@ T C1_128(T xlow,
                (segmentedPi[xpm3] - b + 2);
       }
 
-      NOUNROLL_LOOP
+      NO_UNROLL_LOOP
       for (; j <= max_j; j++)
       {
         uint64_t xpm = fast_div64(xpq, primes[j]);
@@ -912,7 +912,7 @@ T C2_64(T xlow,
   }
 
   // Sparse leaves below the reflected range
-  NOUNROLL_LOOP
+  NO_UNROLL_LOOP
   for (; i <= pi_conj_lo; i++)
   {
     uint64_t xpq = xp / primes[i];
@@ -934,7 +934,7 @@ T C2_64(T xlow,
            (segmentedPi[xpq3] * 2 - b + 2);
   }
 
-  NOUNROLL_LOOP
+  NO_UNROLL_LOOP
   for (; i <= pi_conj_hi; i++)
   {
     uint64_t xpq = xp / primes[i];
@@ -956,7 +956,7 @@ T C2_64(T xlow,
            (segmentedPi[xpq3] - b + 2);
   }
 
-  NOUNROLL_LOOP
+  NO_UNROLL_LOOP
   for (; i <= pi_min_clustered; i++)
   {
     uint64_t xpq = xp / primes[i];
@@ -1030,7 +1030,7 @@ T C2_128(T xlow,
   }
 
   // Sparse leaves below the reflected range
-  NOUNROLL_LOOP
+  NO_UNROLL_LOOP
   for (; i <= pi_conj_lo; i++)
   {
     uint64_t xpq = fast_div64(xp, primes[i]);
@@ -1052,7 +1052,7 @@ T C2_128(T xlow,
            (segmentedPi[xpq3] * 2 - b + 2);
   }
 
-  NOUNROLL_LOOP
+  NO_UNROLL_LOOP
   for (; i <= pi_conj_hi; i++)
   {
     uint64_t xpq = fast_div64(xp, primes[i]);
@@ -1074,7 +1074,7 @@ T C2_128(T xlow,
            (segmentedPi[xpq3] - b + 2);
   }
 
-  NOUNROLL_LOOP
+  NO_UNROLL_LOOP
   for (; i <= pi_min_clustered; i++)
   {
     uint64_t xpq = fast_div64(xp, primes[i]);

--- a/src/sieve/count_simd.hpp
+++ b/src/sieve/count_simd.hpp
@@ -51,7 +51,7 @@
   uint64_t cnt = popcnt64(start_bits); \
   cnt += popcnt64(stop_bits); \
   \
-  NOUNROLL_LOOP \
+  NO_UNROLL_LOOP \
   for (uint64_t i = start_idx + 1; i < stop_idx; i++) \
     cnt += popcnt64(sieve[i]);
 
@@ -83,7 +83,7 @@
   /* Compute this for loop using AVX512. */ \
   /* for (i = start_idx + 1; i < stop_idx; i++) */ \
   /*   cnt += popcnt64(sieve[i]); */ \
-  NOUNROLL_LOOP \
+  NO_UNROLL_LOOP \
   for (; i + 8 < stop_idx; i += 8) \
   { \
     __m512i vec = _mm512_loadu_epi64(&sieve[i]); \
@@ -125,7 +125,7 @@
   /* Compute this for loop using ARM SVE. */ \
   /* for (i = start_idx + 1; i < stop_idx; i++) */ \
   /*   cnt += popcnt64(sieve[i]); */ \
-  NOUNROLL_LOOP \
+  NO_UNROLL_LOOP \
   for (; i + svcntd() < stop_idx; i += svcntd()) \
   { \
     svuint64_t vec = svld1_u64(svptrue_b64(), &sieve[i]); \

--- a/src/sieve/count_stop.hpp
+++ b/src/sieve/count_stop.hpp
@@ -68,7 +68,8 @@ ALWAYS_INLINE uint64_t Sieve::count_popcnt64(uint64_t stop)
   // of the counter array contains the number of
   // unsieved elements in the interval:
   // [i * counter_.dist, (i + 1) * counter_.dist[.
-  NOUNROLL_LOOP
+  NO_UNROLL_LOOP
+  NO_VECTORIZE_LOOP
   while (counter_.stop <= stop)
   {
     start = counter_.stop;
@@ -112,7 +113,8 @@ ALWAYS_INLINE uint64_t Sieve::count_avx512(uint64_t stop)
   // of the counter array contains the number of
   // unsieved elements in the interval:
   // [i * counter_.dist, (i + 1) * counter_.dist[.
-  NOUNROLL_LOOP
+  NO_UNROLL_LOOP
+  NO_VECTORIZE_LOOP
   while (counter_.stop <= stop)
   {
     start = counter_.stop;
@@ -154,7 +156,8 @@ ALWAYS_INLINE uint64_t Sieve::count_arm_sve(uint64_t stop)
   // of the counter array contains the number of
   // unsieved elements in the interval:
   // [i * counter_.dist, (i + 1) * counter_.dist[.
-  NOUNROLL_LOOP
+  NO_UNROLL_LOOP
+  NO_VECTORIZE_LOOP
   while (counter_.stop <= stop)
   {
     start = counter_.stop;


### PR DESCRIPTION
Annotating a specific loop in `count_stop.hpp` using `NO_VECTORIZE_LOOP` improves the performance of the D algorithm using GCC by up to 2%.