### PR TITLE
Reduce Gourdon D memory using 16-bit prime factor ordinals

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
-Changes in primecount-8.7, 2026-08-08
+Changes in primecount-8.7, 2026-08-11
 
 * primecount now requires a C++14 compiler (up from C++11).
+* FactorTableD.hpp: Reduce Gourdon D memory using 16-bit prime factor ordinals #133.
 * D_arm_sve.hpp: Fix GCC ARM SVE failed auto-vectorization.
 * Fix get_max_x() for x > 10^31.
 * CmdOptions.cpp: Detect too many input numbers.

--- a/src/gourdon/D.cpp
+++ b/src/gourdon/D.cpp
@@ -67,7 +67,7 @@ using namespace primecount;
 /// a segmented sieve. Each thread processes the interval
 /// [low, low + segment_size * segments[.
 ///
-template <typename T, typename Primes, typename FactorTableD>
+template <typename T, typename Primes, typename FactorTable>
 T D_thread_default(T x,
                    int64_t x_star,
                    int64_t xz,
@@ -76,7 +76,7 @@ T D_thread_default(T x,
                    int64_t k,
                    const Primes& primes,
                    const PiTable& pi,
-                   const FactorTableD& factor,
+                   const FactorTable& factor,
                    ThreadData& thread)
 {
   T sum = 0;
@@ -123,7 +123,6 @@ T D_thread_default(T x,
     for (int64_t last = min(pi_sqrtz, max_b); b <= last; b++)
     {
       int64_t prime = primes[b];
-      int64_t factor_value = factor.get_filter_value(prime, b);
       T xp = x / prime;
       int64_t xp_low = min(fast_div(xp, low1), z);
       int64_t xp_high = min(fast_div(xp, high), z);
@@ -133,29 +132,30 @@ T D_thread_default(T x,
       if (prime >= max_m)
         goto next_segment;
 
-      min_m = factor.to_index(min_m);
-      max_m = factor.to_index(max_m);
-      std::size_t m_count = 0;
+      min_m = FactorTable::to_index(min_m);
+      max_m = FactorTable::to_index(max_m);
+      int64_t encoded_prime = FactorTable::encode(b);
       int64_t m = max_m;
+      std::size_t m_count = 0;
 
       // 32-bit code path
-      if (FactorTableD::max() <= UINT32_MAX ||
-          max_m <= UINT32_MAX)
+      if (max_m <= UINT32_MAX ||
+          sizeof(T) <= sizeof(uint64_t))
       {
         constexpr std::size_t max_m_count = m_indexes32.size() - 4;
 
         // Filter out square free m values branchlessly
-        // that satisfy: factor_table[m] > factor_value
+        // that satisfy: factor_table[m] > encoded_prime
         for (; m >= min_m + 4; m -= 4)
         {
           m_indexes32[m_count] = uint32_t(m);
-          m_count += (factor_table[m] > factor_value);
+          m_count += (factor_table[m] > encoded_prime);
           m_indexes32[m_count] = uint32_t(m - 1);
-          m_count += (factor_table[m - 1] > factor_value);
+          m_count += (factor_table[m - 1] > encoded_prime);
           m_indexes32[m_count] = uint32_t(m - 2);
-          m_count += (factor_table[m - 2] > factor_value);
+          m_count += (factor_table[m - 2] > encoded_prime);
           m_indexes32[m_count] = uint32_t(m - 3);
-          m_count += (factor_table[m - 3] > factor_value);
+          m_count += (factor_table[m - 3] > encoded_prime);
 
           if (m_count > max_m_count)
           {
@@ -185,7 +185,7 @@ T D_thread_default(T x,
         for (; m > min_m; m--)
         {
           m_indexes32[m_count] = uint32_t(m);
-          m_count += (factor_table[m] > factor_value);
+          m_count += (factor_table[m] > encoded_prime);
         }
 
         // Batch calculate xp/m to improve CPU pipelining
@@ -209,17 +209,17 @@ T D_thread_default(T x,
         constexpr std::size_t max_m_count = m_indexes64.size() - 4;
 
         // Filter out square free m values branchlessly
-        // that satisfy: factor_table[m] > factor_value
+        // that satisfy: factor_table[m] > encoded_prime
         for (; m >= min_m + 4; m -= 4)
         {
           m_indexes64[m_count] = m;
-          m_count += (factor_table[m] > factor_value);
+          m_count += (factor_table[m] > encoded_prime);
           m_indexes64[m_count] = m - 1;
-          m_count += (factor_table[m - 1] > factor_value);
+          m_count += (factor_table[m - 1] > encoded_prime);
           m_indexes64[m_count] = m - 2;
-          m_count += (factor_table[m - 2] > factor_value);
+          m_count += (factor_table[m - 2] > encoded_prime);
           m_indexes64[m_count] = m - 3;
-          m_count += (factor_table[m - 3] > factor_value);
+          m_count += (factor_table[m - 3] > encoded_prime);
 
           if (m_count > max_m_count)
           {
@@ -249,7 +249,7 @@ T D_thread_default(T x,
         for (; m > min_m; m--)
         {
           m_indexes64[m_count] = m;
-          m_count += (factor_table[m] > factor_value);
+          m_count += (factor_table[m] > encoded_prime);
         }
 
         // Batch calculate xp/m to improve CPU pipelining
@@ -380,13 +380,13 @@ string_view_t D_algo_name()
 /// (this is done in D_thread(x, y)) every time the thread starts
 /// a new computation.
 ///
-template <typename T, typename Primes, typename FactorTableD>
+template <typename T, typename Primes, typename FactorTable>
 T D_OpenMP(T x,
            int64_t y,
            int64_t z,
            int64_t k,
            const Primes& primes,
-           const FactorTableD& factor,
+           const FactorTable& factor,
            int threads,
            bool is_print)
 {
@@ -473,18 +473,21 @@ int128_t D(int128_t x,
 
   int128_t sum;
 
-  // uses less memory
+  // Use 16-bit factor table entries whenever possible.
   if (z <= FactorTableD<uint16_t>::max())
   {
     FactorTableD<uint16_t> factor(y, z, threads);
-    auto primes = generate_primes<uint32_t>(y);
-    sum = D_OpenMP(x, y, z, k, primes, factor, threads, is_print);
-  }
-  else if (z <= FactorTableDOrdinal<uint16_t>::max())
-  {
-    FactorTableDOrdinal<uint16_t> factor(y, z, threads);
-    auto primes = generate_primes<int64_t>(y);
-    sum = D_OpenMP(x, y, z, k, primes, factor, threads, is_print);
+
+    if (y <= UINT32_MAX)
+    {
+      auto primes = generate_primes<uint32_t>(y);
+      sum = D_OpenMP(x, y, z, k, primes, factor, threads, is_print);
+    }
+    else
+    {
+      auto primes = generate_primes<int64_t>(y);
+      sum = D_OpenMP(x, y, z, k, primes, factor, threads, is_print);
+    }
   }
   else
   {

--- a/src/gourdon/D.cpp
+++ b/src/gourdon/D.cpp
@@ -123,6 +123,7 @@ T D_thread_default(T x,
     for (int64_t last = min(pi_sqrtz, max_b); b <= last; b++)
     {
       int64_t prime = primes[b];
+      int64_t factor_value = factor.get_filter_value(prime, b);
       T xp = x / prime;
       int64_t xp_low = min(fast_div(xp, low1), z);
       int64_t xp_high = min(fast_div(xp, high), z);
@@ -144,17 +145,17 @@ T D_thread_default(T x,
         constexpr std::size_t max_m_count = m_indexes32.size() - 4;
 
         // Filter out square free m values branchlessly
-        // that satisfy: factor_table[m] > prime
+        // that satisfy: factor_table[m] > factor_value
         for (; m >= min_m + 4; m -= 4)
         {
           m_indexes32[m_count] = uint32_t(m);
-          m_count += (factor_table[m] > prime);
+          m_count += (factor_table[m] > factor_value);
           m_indexes32[m_count] = uint32_t(m - 1);
-          m_count += (factor_table[m - 1] > prime);
+          m_count += (factor_table[m - 1] > factor_value);
           m_indexes32[m_count] = uint32_t(m - 2);
-          m_count += (factor_table[m - 2] > prime);
+          m_count += (factor_table[m - 2] > factor_value);
           m_indexes32[m_count] = uint32_t(m - 3);
-          m_count += (factor_table[m - 3] > prime);
+          m_count += (factor_table[m - 3] > factor_value);
 
           if (m_count > max_m_count)
           {
@@ -184,7 +185,7 @@ T D_thread_default(T x,
         for (; m > min_m; m--)
         {
           m_indexes32[m_count] = uint32_t(m);
-          m_count += (factor_table[m] > prime);
+          m_count += (factor_table[m] > factor_value);
         }
 
         // Batch calculate xp/m to improve CPU pipelining
@@ -208,17 +209,17 @@ T D_thread_default(T x,
         constexpr std::size_t max_m_count = m_indexes64.size() - 4;
 
         // Filter out square free m values branchlessly
-        // that satisfy: factor_table[m] > prime
+        // that satisfy: factor_table[m] > factor_value
         for (; m >= min_m + 4; m -= 4)
         {
           m_indexes64[m_count] = m;
-          m_count += (factor_table[m] > prime);
+          m_count += (factor_table[m] > factor_value);
           m_indexes64[m_count] = m - 1;
-          m_count += (factor_table[m - 1] > prime);
+          m_count += (factor_table[m - 1] > factor_value);
           m_indexes64[m_count] = m - 2;
-          m_count += (factor_table[m - 2] > prime);
+          m_count += (factor_table[m - 2] > factor_value);
           m_indexes64[m_count] = m - 3;
-          m_count += (factor_table[m - 3] > prime);
+          m_count += (factor_table[m - 3] > factor_value);
 
           if (m_count > max_m_count)
           {
@@ -248,7 +249,7 @@ T D_thread_default(T x,
         for (; m > min_m; m--)
         {
           m_indexes64[m_count] = m;
-          m_count += (factor_table[m] > prime);
+          m_count += (factor_table[m] > factor_value);
         }
 
         // Batch calculate xp/m to improve CPU pipelining
@@ -477,6 +478,12 @@ int128_t D(int128_t x,
   {
     FactorTableD<uint16_t> factor(y, z, threads);
     auto primes = generate_primes<uint32_t>(y);
+    sum = D_OpenMP(x, y, z, k, primes, factor, threads, is_print);
+  }
+  else if (z <= FactorTableDOrdinal<uint16_t>::max())
+  {
+    FactorTableDOrdinal<uint16_t> factor(y, z, threads);
+    auto primes = generate_primes<int64_t>(y);
     sum = D_OpenMP(x, y, z, k, primes, factor, threads, is_print);
   }
   else

--- a/src/gourdon/D_arm_sve.hpp
+++ b/src/gourdon/D_arm_sve.hpp
@@ -66,7 +66,7 @@ ALWAYS_INLINE svuint64_t load_factor_u64_arm_sve(svbool_t pg,
   return svrev_u64(svld1uw_u64(pg, factor_table));
 }
 
-template <typename T, typename Primes, typename FactorTableD>
+template <typename T, typename Primes, typename FactorTable>
 #if defined(ENABLE_MULTIARCH_ARM_SVE)
 __attribute__ ((target ("+sve")))
 #endif
@@ -78,7 +78,7 @@ T D_thread_arm_sve(T x,
                    int64_t k,
                    const Primes& primes,
                    const PiTable& pi,
-                   const FactorTableD& factor,
+                   const FactorTable& factor,
                    ThreadData& thread)
 {
   T sum = 0;
@@ -125,7 +125,6 @@ T D_thread_arm_sve(T x,
     for (int64_t last = min(pi_sqrtz, max_b); b <= last; b++)
     {
       int64_t prime = primes[b];
-      int64_t factor_value = factor.get_filter_value(prime, b);
       T xp = x / prime;
       int64_t xp_low = min(fast_div(xp, low1), z);
       int64_t xp_high = min(fast_div(xp, high), z);
@@ -135,14 +134,15 @@ T D_thread_arm_sve(T x,
       if (prime >= max_m)
         goto next_segment;
 
-      min_m = factor.to_index(min_m);
-      max_m = factor.to_index(max_m);
-      std::size_t m_count = 0;
+      min_m = FactorTable::to_index(min_m);
+      max_m = FactorTable::to_index(max_m);
+      int64_t encoded_prime = FactorTable::encode(b);
       int64_t m = max_m;
+      std::size_t m_count = 0;
 
       // ARM SVE 32-bit
-      if (FactorTableD::max() <= UINT32_MAX ||
-          max_m <= UINT32_MAX)
+      if (max_m <= UINT32_MAX ||
+          sizeof(T) <= sizeof(uint64_t))
       {
         int64_t lanes32 = svcntw();
         ASSERT(svcntw() <= m_indexes32.size());
@@ -166,10 +166,10 @@ T D_thread_arm_sve(T x,
         for (; m >= min_m + lanes32; m -= lanes32)
         {
           // Filter out square free m values using ARM SVE
-          // that satisfy: factor_table[m] > factor_value
+          // that satisfy: factor_table[m] > encoded_prime
           svuint32_t m_vec = svsub_u32_x(all32, svdup_n_u32(uint32_t(m)), m_offsets32);
           svuint32_t factor_vec = load_factor_u32_arm_sve(all32, &factor_table[m + 1 - lanes32]);
-          svbool_t mask = svcmpgt_n_u32(all32, factor_vec, uint32_t(factor_value));
+          svbool_t mask = svcmpgt_n_u32(all32, factor_vec, uint32_t(encoded_prime));
           int64_t matches = svcntp_b32(all32, mask);
           svuint32_t compact = svcompact_u32(mask, m_vec);
           svst1_u32(all32, &m_indexes32[m_count], compact);
@@ -207,7 +207,7 @@ T D_thread_arm_sve(T x,
           uint32_t base = uint32_t(m + lanes32 - lane_count);
           svuint32_t m_vec = svsub_u32_x(all32, svdup_n_u32(base), m_offsets32);
           svuint32_t factor_vec = load_factor_u32_arm_sve(load_pg, &factor_table[m + 1 - lane_count]);
-          svbool_t mask = svcmpgt_n_u32(store_pg, factor_vec, uint32_t(factor_value));
+          svbool_t mask = svcmpgt_n_u32(store_pg, factor_vec, uint32_t(encoded_prime));
           int64_t matches = svcntp_b32(store_pg, mask);
           svuint32_t compact = svcompact_u32(mask, m_vec);
           svbool_t compact_pg = svwhilelt_b32(int64_t(0), matches);
@@ -254,10 +254,10 @@ T D_thread_arm_sve(T x,
         for (; m >= min_m + lanes64; m -= lanes64)
         {
           // Filter out square free m values using ARM SVE
-          // that satisfy: factor_table[m] > factor_value
+          // that satisfy: factor_table[m] > encoded_prime
           svuint64_t m_vec = svsub_u64_x(all64, svdup_n_u64(uint64_t(m)), m_offsets64);
           svuint64_t factor_vec = load_factor_u64_arm_sve(all64, &factor_table[m + 1 - lanes64]);
-          svbool_t mask = svcmpgt_n_u64(all64, factor_vec, uint64_t(factor_value));
+          svbool_t mask = svcmpgt_n_u64(all64, factor_vec, uint64_t(encoded_prime));
           int64_t matches = svcntp_b64(all64, mask);
           svint64_t compact = svreinterpret_s64_u64(svcompact_u64(mask, m_vec));
           svst1_s64(all64, &m_indexes64[m_count], compact);
@@ -295,7 +295,7 @@ T D_thread_arm_sve(T x,
           uint64_t base = uint64_t(m + lanes64 - lane_count);
           svuint64_t m_vec = svsub_u64_x(all64, svdup_n_u64(base), m_offsets64);
           svuint64_t factor_vec = load_factor_u64_arm_sve(load_pg, &factor_table[m + 1 - lane_count]);
-          svbool_t mask = svcmpgt_n_u64(store_pg, factor_vec, uint64_t(factor_value));
+          svbool_t mask = svcmpgt_n_u64(store_pg, factor_vec, uint64_t(encoded_prime));
           int64_t matches = svcntp_b64(store_pg, mask);
           svint64_t compact = svreinterpret_s64_u64(svcompact_u64(mask, m_vec));
           svbool_t compact_pg = svwhilelt_b64(int64_t(0), matches);

--- a/src/gourdon/D_arm_sve.hpp
+++ b/src/gourdon/D_arm_sve.hpp
@@ -125,6 +125,7 @@ T D_thread_arm_sve(T x,
     for (int64_t last = min(pi_sqrtz, max_b); b <= last; b++)
     {
       int64_t prime = primes[b];
+      int64_t factor_value = factor.get_filter_value(prime, b);
       T xp = x / prime;
       int64_t xp_low = min(fast_div(xp, low1), z);
       int64_t xp_high = min(fast_div(xp, high), z);
@@ -165,10 +166,10 @@ T D_thread_arm_sve(T x,
         for (; m >= min_m + lanes32; m -= lanes32)
         {
           // Filter out square free m values using ARM SVE
-          // that satisfy: factor_table[m] > prime
+          // that satisfy: factor_table[m] > factor_value
           svuint32_t m_vec = svsub_u32_x(all32, svdup_n_u32(uint32_t(m)), m_offsets32);
           svuint32_t factor_vec = load_factor_u32_arm_sve(all32, &factor_table[m + 1 - lanes32]);
-          svbool_t mask = svcmpgt_n_u32(all32, factor_vec, uint32_t(prime));
+          svbool_t mask = svcmpgt_n_u32(all32, factor_vec, uint32_t(factor_value));
           int64_t matches = svcntp_b32(all32, mask);
           svuint32_t compact = svcompact_u32(mask, m_vec);
           svst1_u32(all32, &m_indexes32[m_count], compact);
@@ -206,7 +207,7 @@ T D_thread_arm_sve(T x,
           uint32_t base = uint32_t(m + lanes32 - lane_count);
           svuint32_t m_vec = svsub_u32_x(all32, svdup_n_u32(base), m_offsets32);
           svuint32_t factor_vec = load_factor_u32_arm_sve(load_pg, &factor_table[m + 1 - lane_count]);
-          svbool_t mask = svcmpgt_n_u32(store_pg, factor_vec, uint32_t(prime));
+          svbool_t mask = svcmpgt_n_u32(store_pg, factor_vec, uint32_t(factor_value));
           int64_t matches = svcntp_b32(store_pg, mask);
           svuint32_t compact = svcompact_u32(mask, m_vec);
           svbool_t compact_pg = svwhilelt_b32(int64_t(0), matches);
@@ -253,10 +254,10 @@ T D_thread_arm_sve(T x,
         for (; m >= min_m + lanes64; m -= lanes64)
         {
           // Filter out square free m values using ARM SVE
-          // that satisfy: factor_table[m] > prime
+          // that satisfy: factor_table[m] > factor_value
           svuint64_t m_vec = svsub_u64_x(all64, svdup_n_u64(uint64_t(m)), m_offsets64);
           svuint64_t factor_vec = load_factor_u64_arm_sve(all64, &factor_table[m + 1 - lanes64]);
-          svbool_t mask = svcmpgt_n_u64(all64, factor_vec, uint64_t(prime));
+          svbool_t mask = svcmpgt_n_u64(all64, factor_vec, uint64_t(factor_value));
           int64_t matches = svcntp_b64(all64, mask);
           svint64_t compact = svreinterpret_s64_u64(svcompact_u64(mask, m_vec));
           svst1_s64(all64, &m_indexes64[m_count], compact);
@@ -294,7 +295,7 @@ T D_thread_arm_sve(T x,
           uint64_t base = uint64_t(m + lanes64 - lane_count);
           svuint64_t m_vec = svsub_u64_x(all64, svdup_n_u64(base), m_offsets64);
           svuint64_t factor_vec = load_factor_u64_arm_sve(load_pg, &factor_table[m + 1 - lane_count]);
-          svbool_t mask = svcmpgt_n_u64(store_pg, factor_vec, uint64_t(prime));
+          svbool_t mask = svcmpgt_n_u64(store_pg, factor_vec, uint64_t(factor_value));
           int64_t matches = svcntp_b64(store_pg, mask);
           svint64_t compact = svreinterpret_s64_u64(svcompact_u64(mask, m_vec));
           svbool_t compact_pg = svwhilelt_b64(int64_t(0), matches);

--- a/src/gourdon/D_avx512.hpp
+++ b/src/gourdon/D_avx512.hpp
@@ -192,6 +192,7 @@ T D_thread_avx512(T x,
     for (int64_t last = min(pi_sqrtz, max_b); b <= last; b++)
     {
       int64_t prime = primes[b];
+      int64_t factor_value = factor.get_filter_value(prime, b);
       T xp = x / prime;
       int64_t xp_low = min(fast_div(xp, low1), z);
       int64_t xp_high = min(fast_div(xp, high), z);
@@ -210,13 +211,13 @@ T D_thread_avx512(T x,
       if (FactorTableD::max() <= UINT32_MAX ||
           max_m <= UINT32_MAX)
       {
-        __m512i prime_vec = _mm512_set1_epi32(uint32_t(prime));
+        __m512i prime_vec = _mm512_set1_epi32(uint32_t(factor_value));
         constexpr std::size_t max_m_count = m_indexes32.size() - 16;
 
         for (; m >= min_m + 16; m -= 16)
         {
           // Filter out square free m values using AVX512
-          // that satisfy: factor_table[m] > prime
+          // that satisfy: factor_table[m] > factor_value
           __m512i m_vec = _mm512_sub_epi32(_mm512_set1_epi32(uint32_t(m)), m_offsets32);
           __m512i factor_vec = load_factor_epi32_avx512(&factor_table[m - 15], reverse32);
           __mmask16 mask = _mm512_cmpgt_epu32_mask(factor_vec, prime_vec);
@@ -277,13 +278,13 @@ T D_thread_avx512(T x,
       }
       else // AVX512: 8-lane 64-bit
       {
-        __m512i prime_vec = _mm512_set1_epi64(prime);
+        __m512i prime_vec = _mm512_set1_epi64(factor_value);
         constexpr std::size_t max_m_count = m_indexes64.size() - 8;
 
         for (; m >= min_m + 8; m -= 8)
         {
           // Filter out square free m values using AVX512
-          // that satisfy: factor_table[m] > prime
+          // that satisfy: factor_table[m] > factor_value
           __m512i m_vec = _mm512_sub_epi64(_mm512_set1_epi64(m), m_offsets64);
           __m512i factor_vec = load_factor_epi64_avx512(&factor_table[m - 7], reverse64);
           __mmask8 mask = _mm512_cmpgt_epi64_mask(factor_vec, prime_vec);

--- a/src/gourdon/D_avx512.hpp
+++ b/src/gourdon/D_avx512.hpp
@@ -128,7 +128,7 @@ ALWAYS_INLINE __m512i load_factor_tail_epi64_avx512(const uint32_t* factor_table
                                         _mm512_cvtepu32_epi64(vec));
 }
 
-template <typename T, typename Primes, typename FactorTableD>
+template <typename T, typename Primes, typename FactorTable>
 #if defined(ENABLE_MULTIARCH_AVX512_VPOPCNT)
   __attribute__ ((target ("avx512f,avx512bw,avx512vl,avx512vpopcntdq")))
 #endif
@@ -140,7 +140,7 @@ T D_thread_avx512(T x,
                   int64_t k,
                   const Primes& primes,
                   const PiTable& pi,
-                  const FactorTableD& factor,
+                  const FactorTable& factor,
                   ThreadData& thread)
 {
   int64_t low = thread.low;
@@ -192,7 +192,6 @@ T D_thread_avx512(T x,
     for (int64_t last = min(pi_sqrtz, max_b); b <= last; b++)
     {
       int64_t prime = primes[b];
-      int64_t factor_value = factor.get_filter_value(prime, b);
       T xp = x / prime;
       int64_t xp_low = min(fast_div(xp, low1), z);
       int64_t xp_high = min(fast_div(xp, high), z);
@@ -202,25 +201,26 @@ T D_thread_avx512(T x,
       if (prime >= max_m)
         goto next_segment;
 
-      min_m = factor.to_index(min_m);
-      max_m = factor.to_index(max_m);
-      std::size_t m_count = 0;
+      min_m = FactorTable::to_index(min_m);
+      max_m = FactorTable::to_index(max_m);
+      int64_t encoded_prime = FactorTable::encode(b);
       int64_t m = max_m;
+      std::size_t m_count = 0;
 
       // AVX512: 16-lane 32-bit
-      if (FactorTableD::max() <= UINT32_MAX ||
-          max_m <= UINT32_MAX)
+      if (max_m <= UINT32_MAX ||
+          sizeof(T) <= sizeof(uint64_t))
       {
-        __m512i prime_vec = _mm512_set1_epi32(uint32_t(factor_value));
+        __m512i encoded_prime_vec = _mm512_set1_epi32(uint32_t(encoded_prime));
         constexpr std::size_t max_m_count = m_indexes32.size() - 16;
 
         for (; m >= min_m + 16; m -= 16)
         {
           // Filter out square free m values using AVX512
-          // that satisfy: factor_table[m] > factor_value
+          // that satisfy: factor_table[m] > encoded_prime
           __m512i m_vec = _mm512_sub_epi32(_mm512_set1_epi32(uint32_t(m)), m_offsets32);
           __m512i factor_vec = load_factor_epi32_avx512(&factor_table[m - 15], reverse32);
-          __mmask16 mask = _mm512_cmpgt_epu32_mask(factor_vec, prime_vec);
+          __mmask16 mask = _mm512_cmpgt_epu32_mask(factor_vec, encoded_prime_vec);
           _mm512_mask_compressstoreu_epi32(&m_indexes32[m_count], mask, m_vec);
           m_count += popcnt64_native(mask);
 
@@ -255,7 +255,7 @@ T D_thread_avx512(T x,
           __mmask16 load_mask = __mmask16((1u << count) - 1);
           __m512i m_vec = _mm512_sub_epi32(_mm512_set1_epi32(uint32_t(m)), m_offsets32);
           __m512i factor_vec = load_factor_tail_epi32_avx512(&factor_table[min_m + 1], load_mask, count, m_offsets32);
-          __mmask16 mask = _mm512_cmpgt_epu32_mask(factor_vec, prime_vec);
+          __mmask16 mask = _mm512_cmpgt_epu32_mask(factor_vec, encoded_prime_vec);
           _mm512_mask_compressstoreu_epi32(&m_indexes32[m_count], mask, m_vec);
           m_count += popcnt64_native(mask);
         }
@@ -278,16 +278,16 @@ T D_thread_avx512(T x,
       }
       else // AVX512: 8-lane 64-bit
       {
-        __m512i prime_vec = _mm512_set1_epi64(factor_value);
+        __m512i encoded_prime_vec = _mm512_set1_epi64(encoded_prime);
         constexpr std::size_t max_m_count = m_indexes64.size() - 8;
 
         for (; m >= min_m + 8; m -= 8)
         {
           // Filter out square free m values using AVX512
-          // that satisfy: factor_table[m] > factor_value
+          // that satisfy: factor_table[m] > encoded_prime
           __m512i m_vec = _mm512_sub_epi64(_mm512_set1_epi64(m), m_offsets64);
           __m512i factor_vec = load_factor_epi64_avx512(&factor_table[m - 7], reverse64);
-          __mmask8 mask = _mm512_cmpgt_epi64_mask(factor_vec, prime_vec);
+          __mmask8 mask = _mm512_cmpgt_epi64_mask(factor_vec, encoded_prime_vec);
           _mm512_mask_compressstoreu_epi64(&m_indexes64[m_count], mask, m_vec);
           m_count += popcnt64_native(mask);
 
@@ -322,7 +322,7 @@ T D_thread_avx512(T x,
           __mmask8 load_mask = __mmask8((1u << count) - 1);
           __m512i m_vec = _mm512_sub_epi64(_mm512_set1_epi64(m), m_offsets64);
           __m512i factor_vec = load_factor_tail_epi64_avx512(&factor_table[min_m + 1], load_mask, count, m_offsets64);
-          __mmask8 mask = _mm512_cmpgt_epi64_mask(factor_vec, prime_vec);
+          __mmask8 mask = _mm512_cmpgt_epi64_mask(factor_vec, encoded_prime_vec);
           _mm512_mask_compressstoreu_epi64(&m_indexes64[m_count], mask, m_vec);
           m_count += popcnt64_native(mask);
         }

--- a/src/gourdon/FactorTableD.hpp
+++ b/src/gourdon/FactorTableD.hpp
@@ -96,9 +96,7 @@ public:
     int64_t thread_threshold = (int64_t) 1e7;
     threads = ideal_num_threads(z, threads, thread_threshold);
     int64_t thread_distance = ceil_div(z, threads);
-    int64_t thread_alignment = coprime_indexes_.size();
-
-    thread_distance += thread_alignment - thread_distance % thread_alignment;
+    thread_distance += coprime_indexes_.size() - thread_distance % coprime_indexes_.size();
 
     #pragma omp parallel for num_threads(threads)
     for (int t = 0; t < threads; t++)
@@ -114,7 +112,6 @@ public:
         // Default initialize memory to all bits set
         int64_t low_idx = to_index(low);
         int64_t size = (to_index(high) + 1) - low_idx;
-
         std::fill_n(&factor_[low_idx], size, T_MAX);
 
         int64_t start = first_coprime();

--- a/src/gourdon/FactorTableD.hpp
+++ b/src/gourdon/FactorTableD.hpp
@@ -7,9 +7,7 @@
 ///        which are not divisible by 2, 3, 5, 7 and 11. The factor[n]
 ///        lookup table uses up to 28 times less memory than the
 ///        lpf[n], mpf[n] and mu[n] lookup tables! factor[n] uses only
-///        2 bytes per entry for 32-bit numbers and 4 bytes per entry
-///        for 64-bit numbers. The 16-bit ordinal format additionally
-///        uses one Möbius bit per entry (about 2.125 bytes per entry).
+///        2 or 4 bytes per entry.
 ///
 ///        The factor table concept was devised and implemented by
 ///        Christian Bau in 2003. Note that Tomás Oliveira e Silva
@@ -19,15 +17,16 @@
 ///        slightly more efficient (uses fewer instructions) than the
 ///        data structure proposed by Tomás Oliveira e Silva.
 ///
-///        By default we store the numerical least prime factor and
-///        the Möbius sign in the factor[n] lookup table:
+///        factor[n] stores the index pi(lpf) of the least prime
+///        factor and the Möbius sign. As pi(lpf) is far smaller
+///        than lpf this allows 2 byte entries up to a much larger n:
 ///
-///        1) INT_MAX - 1  if n = 1
-///        2) INT_MAX      if n is a prime
-///        3) 0            if n has a prime factor > y
-///        4) 0            if moebius(n) = 0
-///        5) lpf - 1      if moebius(n) = 1
-///        6) lpf          if moebius(n) = -1
+///        1) INT_MAX - 1    if n = 1
+///        2) INT_MAX        if n is a prime
+///        3) 0              if n has a prime factor > y
+///        4) 0              if moebius(n) = 0
+///        5) 2*pi(lpf)      if moebius(n) = 1
+///        6) 2*pi(lpf) + 1  if moebius(n) = -1
 ///
 ///        factor[1] = (INT_MAX - 1) because 1 contributes to the
 ///        sum of the ordinary leaves S1(x, a) in the
@@ -37,14 +36,7 @@
 ///        statement which is obviously faster.
 ///
 ///        * Old: if (mu[n] != 0 && lpf[n] > prime && mpf[n] <= y)
-///        * New: if (factor[n] > prime)
-///
-///        FactorTableD<T, true> instead stores the ordinal of the
-///        least prime factor. Its Möbius sign is stored in a separate
-///        bitmap. This format allows a 16-bit factor table to be used
-///        for much larger z values. In this mode the filter becomes:
-///
-///        * Ordinal: if (factor[n] > pi(prime))
+///        * New: if (factor[n] > 2*pi(prime) + 1)
 ///
 ///        In-depth description of the factor table data structure:
 ///        https://github.com/kimwalisch/primecount/blob/master/doc/Hard-Special-Leaves-SIMD-Filtering.pdf
@@ -74,11 +66,13 @@ namespace {
 
 using namespace primecount;
 
-template <typename T, bool store_ordinal = false>
+template <typename T>
 class FactorTableD : public BaseFactorTable
 {
 public:
-  using value_type = T;
+  static_assert(sizeof(T) == sizeof(uint16_t) ||
+                sizeof(T) == sizeof(uint32_t),
+                "FactorTableD: T must be uint16_t or uint32_t!");
 
   /// Factor numbers <= z
   FactorTableD(int64_t y,
@@ -86,7 +80,7 @@ public:
                int threads)
   {
     if_unlikely(z > max())
-      throw primecount_error("z must be <= FactorTable::max()");
+      throw primecount_error("z must be <= FactorTableD::max()");
 
     z = std::max<int64_t>(1, z);
     T T_MAX = pstd::numeric_limits<T>::max();
@@ -94,9 +88,8 @@ public:
 
     // mu(1) = 1.
     // 1 has zero prime factors, hence 1 has an even
-    // number of prime factors. The numerical encoding uses the
-    // least significant factor bit, the ordinal encoding uses its
-    // separate Möbius bitmap.
+    // number of prime factors. The least significant bit
+    // of factor[n] stores the Möbius sign.
     factor_[0] = T_MAX ^ 1;
 
     int64_t sqrtz = isqrt(z);
@@ -105,21 +98,7 @@ public:
     int64_t thread_distance = ceil_div(z, threads);
     int64_t thread_alignment = coprime_indexes_.size();
 
-    // In ordinal mode each thread must write to disjoint Möbius
-    // bitmap words. Two wheel intervals contain 960 factor table
-    // entries, which is divisible by 64.
-    if (store_ordinal)
-      thread_alignment *= 2;
-
     thread_distance += thread_alignment - thread_distance % thread_alignment;
-
-    if (store_ordinal)
-    {
-      std::size_t words = (factor_.size() + 63) / 64;
-      moebius_.resize(words);
-      std::fill(moebius_.begin(), moebius_.end(), UINT64_MAX);
-      moebius_[0] &= ~uint64_t(1);
-    }
 
     #pragma omp parallel for num_threads(threads)
     for (int t = 0; t < threads; t++)
@@ -136,9 +115,6 @@ public:
         int64_t low_idx = to_index(low);
         int64_t size = (to_index(high) + 1) - low_idx;
 
-        if (store_ordinal && t > 0)
-          ASSERT(low_idx % 64 == 0);
-
         std::fill_n(&factor_[low_idx], size, T_MAX);
 
         int64_t start = first_coprime();
@@ -148,15 +124,15 @@ public:
 
         if (min_m <= high)
         {
-          // pi(11) = 5, the first iterator prime is 13.
-          int64_t prime_index = 5;
+          // PrimePi(13) = 6
+          ASSERT(first_coprime() == 13);
+          int64_t prime_index = 6;
 
-          while (true)
+          for (; true; prime_index++)
           {
             // Find multiples > prime
             int64_t i = 1;
             int64_t prime = it.next_prime();
-            prime_index++;
             int64_t multiple = next_multiple(prime, low, &i);
             min_m = prime * first_coprime();
 
@@ -168,11 +144,14 @@ public:
               int64_t mi = to_index(multiple);
               // prime is the smallest factor of multiple
               if (factor_[mi] == T_MAX)
-                factor_[mi] = encode_factor(prime, prime_index);
+              {
+                ASSERT(encode(prime_index) <= T_MAX - 2);
+                factor_[mi] = (T) encode(prime_index);
+              }
               // Toggle whether multiple has an even or odd number
               // of distinct prime factors.
               else if (factor_[mi] != 0)
-                toggle_moebius(mi);
+                factor_[mi] ^= 1;
             }
 
             if (prime <= sqrtz)
@@ -216,23 +195,19 @@ public:
     }
   }
 
-  /// Returns true if n (with n = to_number(index)) is a
-  /// hard special leaf in the D formula of Xavier
-  /// Gourdon's prime counting algorithm.
+  /// Returns the factor table entry for the number
+  /// n = to_number(index).
   ///
   /// Return value:
   ///
-  /// 1) INT_MAX - 1  if n = 1
-  /// 2) INT_MAX      if n is a prime
-  /// 3) 0            if n has a prime factor > y
-  /// 4) 0            if moebius(n) = 0
-  /// 5) lpf - 1      if moebius(n) = 1
-  /// 6) lpf          if moebius(n) = -1
+  /// 1) INT_MAX - 1    if n = 1
+  /// 2) INT_MAX        if n is a prime
+  /// 3) 0              if n has a prime factor > y
+  /// 4) 0              if moebius(n) = 0
+  /// 5) 2*pi(lpf)      if moebius(n) = 1
+  /// 6) 2*pi(lpf) + 1  if moebius(n) = -1
   ///
-  /// In ordinal mode composite leaves instead store pi(lpf),
-  /// while the two sentinel values and zero keep the same meaning.
-  ///
-  int64_t is_leaf(int64_t index) const
+  int64_t operator[](int64_t index) const
   {
     return factor_[index];
   }
@@ -242,12 +217,10 @@ public:
     return factor_.data();
   }
 
-  /// Convert the current prime into the value used by the hot
-  /// factor_table[m] > filter comparison.
-  int64_t get_filter_value(int64_t prime,
-                           int64_t prime_index) const
+  /// Encode prime index for use in the factor table
+  static int64_t encode(int64_t prime_index)
   {
-    return store_ordinal ? prime_index : prime;
+    return prime_index * 2 + 1;
   }
 
   /// Get the Möbius function value of the number
@@ -269,93 +242,25 @@ public:
       ASSERT(factor_[index] != 0);
     #endif
 
-    if (store_ordinal)
-    {
-      std::size_t word = (std::size_t) index / 64;
-      uint64_t bit = uint64_t(1) << (index % 64);
-      return (moebius_[word] & bit) ? -1 : 1;
-    }
-    else if (factor_[index] & 1)
+    if (factor_[index] & 1)
       return -1;
     else
       return 1;
   }
 
-#if __cplusplus >= 201402L
-
   static constexpr int64_t max()
   {
-    static_assert(sizeof(T) * 2 <= sizeof(uint64_t), "FactorTableD: sizeof(T) is too large!");
-    static_assert(!store_ordinal ||
-                  sizeof(T) <= sizeof(uint16_t),
-                  "Ordinal FactorTableD only supports 8-bit and 16-bit values!");
-    constexpr uint64_t MAX_T = pstd::numeric_limits<T>::max();
-    constexpr uint64_t MAX_INT64_T = pstd::numeric_limits<int64_t>::max();
-    constexpr uint64_t MAX_M_NUMERIC = (MAX_T - 1) * (MAX_T - 1) - 1;
-
-    // Codes T_MAX - 1 and T_MAX are reserved for n = 1 and primes.
-    // p(254) = 1609 and p(65534) = 821573 are therefore the first
-    // unencodable least prime factors for 8-bit and 16-bit ordinals.
-    constexpr uint64_t FIRST_UNENCODABLE_PRIME =
-      sizeof(T) == sizeof(uint8_t) ? 1609 : 821573;
-    constexpr uint64_t MAX_M_ORDINAL =
-      FIRST_UNENCODABLE_PRIME * FIRST_UNENCODABLE_PRIME - 1;
-    constexpr uint64_t MAX_M = store_ordinal ? MAX_M_ORDINAL : MAX_M_NUMERIC;
-    return (int64_t) std::min(MAX_M, MAX_INT64_T);
+    // The least prime factor is <= sqrt(z) and with 16-bit
+    // entries p(32767) = 386083 is the first prime whose
+    // index cannot be encoded, hence z < 386083^2.
+    return sizeof(T) == sizeof(uint16_t)
+      ? 386083ll * 386083 - 1
+      : pstd::numeric_limits<int64_t>::max();
   }
-
-#else
-
-  static int64_t max()
-  {
-    static_assert(sizeof(T) * 2 <= sizeof(uint64_t), "FactorTableD: sizeof(T) is too large!");
-    static_assert(!store_ordinal ||
-                  sizeof(T) <= sizeof(uint16_t),
-                  "Ordinal FactorTableD only supports 8-bit and 16-bit values!");
-    uint64_t MAX_T = pstd::numeric_limits<T>::max();
-    uint64_t MAX_INT64_T = pstd::numeric_limits<int64_t>::max();
-    uint64_t MAX_M_NUMERIC = (MAX_T - 1) * (MAX_T - 1) - 1;
-    uint64_t FIRST_UNENCODABLE_PRIME =
-      sizeof(T) == sizeof(uint8_t) ? 1609 : 821573;
-    uint64_t MAX_M_ORDINAL =
-      FIRST_UNENCODABLE_PRIME * FIRST_UNENCODABLE_PRIME - 1;
-    uint64_t MAX_M = store_ordinal ? MAX_M_ORDINAL : MAX_M_NUMERIC;
-    return (int64_t) std::min(MAX_M, MAX_INT64_T);
-  }
-
-#endif
 
 private:
-  static T encode_factor(int64_t prime,
-                         int64_t prime_index)
-  {
-    if (store_ordinal)
-    {
-      ASSERT(prime_index <= (int64_t) pstd::numeric_limits<T>::max() - 2);
-      return (T) prime_index;
-    }
-    else
-      return (T) prime;
-  }
-
-  void toggle_moebius(int64_t index)
-  {
-    if (store_ordinal)
-    {
-      std::size_t word = (std::size_t) index / 64;
-      uint64_t bit = uint64_t(1) << (index % 64);
-      moebius_[word] ^= bit;
-    }
-    else
-      factor_[index] ^= 1;
-  }
-
   Vector<T> factor_;
-  Vector<uint64_t> moebius_;
 };
-
-template <typename T>
-using FactorTableDOrdinal = FactorTableD<T, true>;
 
 } // namespace
 

--- a/src/gourdon/FactorTableD.hpp
+++ b/src/gourdon/FactorTableD.hpp
@@ -8,7 +8,8 @@
 ///        lookup table uses up to 28 times less memory than the
 ///        lpf[n], mpf[n] and mu[n] lookup tables! factor[n] uses only
 ///        2 bytes per entry for 32-bit numbers and 4 bytes per entry
-///        for 64-bit numbers.
+///        for 64-bit numbers. The 16-bit ordinal format additionally
+///        uses one Möbius bit per entry (about 2.125 bytes per entry).
 ///
 ///        The factor table concept was devised and implemented by
 ///        Christian Bau in 2003. Note that Tomás Oliveira e Silva
@@ -18,7 +19,8 @@
 ///        slightly more efficient (uses fewer instructions) than the
 ///        data structure proposed by Tomás Oliveira e Silva.
 ///
-///        What we store in the factor[n] lookup table:
+///        By default we store the numerical least prime factor and
+///        the Möbius sign in the factor[n] lookup table:
 ///
 ///        1) INT_MAX - 1  if n = 1
 ///        2) INT_MAX      if n is a prime
@@ -36,6 +38,13 @@
 ///
 ///        * Old: if (mu[n] != 0 && lpf[n] > prime && mpf[n] <= y)
 ///        * New: if (factor[n] > prime)
+///
+///        FactorTableD<T, true> instead stores the ordinal of the
+///        least prime factor. Its Möbius sign is stored in a separate
+///        bitmap. This format allows a 16-bit factor table to be used
+///        for much larger z values. In this mode the filter becomes:
+///
+///        * Ordinal: if (factor[n] > pi(prime))
 ///
 ///        In-depth description of the factor table data structure:
 ///        https://github.com/kimwalisch/primecount/blob/master/doc/Hard-Special-Leaves-SIMD-Filtering.pdf
@@ -65,7 +74,7 @@ namespace {
 
 using namespace primecount;
 
-template <typename T>
+template <typename T, bool store_ordinal = false>
 class FactorTableD : public BaseFactorTable
 {
 public:
@@ -85,16 +94,32 @@ public:
 
     // mu(1) = 1.
     // 1 has zero prime factors, hence 1 has an even
-    // number of prime factors. We use the least
-    // significant bit to indicate whether the number
-    // has an even or odd number of prime factors.
+    // number of prime factors. The numerical encoding uses the
+    // least significant factor bit, the ordinal encoding uses its
+    // separate Möbius bitmap.
     factor_[0] = T_MAX ^ 1;
 
     int64_t sqrtz = isqrt(z);
     int64_t thread_threshold = (int64_t) 1e7;
     threads = ideal_num_threads(z, threads, thread_threshold);
     int64_t thread_distance = ceil_div(z, threads);
-    thread_distance += coprime_indexes_.size() - thread_distance % coprime_indexes_.size();
+    int64_t thread_alignment = coprime_indexes_.size();
+
+    // In ordinal mode each thread must write to disjoint Möbius
+    // bitmap words. Two wheel intervals contain 960 factor table
+    // entries, which is divisible by 64.
+    if (store_ordinal)
+      thread_alignment *= 2;
+
+    thread_distance += thread_alignment - thread_distance % thread_alignment;
+
+    if (store_ordinal)
+    {
+      std::size_t words = (factor_.size() + 63) / 64;
+      moebius_.resize(words);
+      std::fill(moebius_.begin(), moebius_.end(), UINT64_MAX);
+      moebius_[0] &= ~uint64_t(1);
+    }
 
     #pragma omp parallel for num_threads(threads)
     for (int t = 0; t < threads; t++)
@@ -110,6 +135,10 @@ public:
         // Default initialize memory to all bits set
         int64_t low_idx = to_index(low);
         int64_t size = (to_index(high) + 1) - low_idx;
+
+        if (store_ordinal && t > 0)
+          ASSERT(low_idx % 64 == 0);
+
         std::fill_n(&factor_[low_idx], size, T_MAX);
 
         int64_t start = first_coprime();
@@ -119,11 +148,15 @@ public:
 
         if (min_m <= high)
         {
+          // pi(11) = 5, the first iterator prime is 13.
+          int64_t prime_index = 5;
+
           while (true)
           {
             // Find multiples > prime
             int64_t i = 1;
             int64_t prime = it.next_prime();
+            prime_index++;
             int64_t multiple = next_multiple(prime, low, &i);
             min_m = prime * first_coprime();
 
@@ -135,12 +168,11 @@ public:
               int64_t mi = to_index(multiple);
               // prime is the smallest factor of multiple
               if (factor_[mi] == T_MAX)
-                factor_[mi] = (T) prime;
-              // the least significant bit indicates
-              // whether multiple has an even (0) or odd (1)
-              // number of prime factors
+                factor_[mi] = encode_factor(prime, prime_index);
+              // Toggle whether multiple has an even or odd number
+              // of distinct prime factors.
               else if (factor_[mi] != 0)
-                factor_[mi] ^= 1;
+                toggle_moebius(mi);
             }
 
             if (prime <= sqrtz)
@@ -197,6 +229,9 @@ public:
   /// 5) lpf - 1      if moebius(n) = 1
   /// 6) lpf          if moebius(n) = -1
   ///
+  /// In ordinal mode composite leaves instead store pi(lpf),
+  /// while the two sentinel values and zero keep the same meaning.
+  ///
   int64_t is_leaf(int64_t index) const
   {
     return factor_[index];
@@ -205,6 +240,14 @@ public:
   const T* data() const
   {
     return factor_.data();
+  }
+
+  /// Convert the current prime into the value used by the hot
+  /// factor_table[m] > filter comparison.
+  int64_t get_filter_value(int64_t prime,
+                           int64_t prime_index) const
+  {
+    return store_ordinal ? prime_index : prime;
   }
 
   /// Get the Möbius function value of the number
@@ -226,7 +269,13 @@ public:
       ASSERT(factor_[index] != 0);
     #endif
 
-    if (factor_[index] & 1)
+    if (store_ordinal)
+    {
+      std::size_t word = (std::size_t) index / 64;
+      uint64_t bit = uint64_t(1) << (index % 64);
+      return (moebius_[word] & bit) ? -1 : 1;
+    }
+    else if (factor_[index] & 1)
       return -1;
     else
       return 1;
@@ -237,9 +286,21 @@ public:
   static constexpr int64_t max()
   {
     static_assert(sizeof(T) * 2 <= sizeof(uint64_t), "FactorTableD: sizeof(T) is too large!");
+    static_assert(!store_ordinal ||
+                  sizeof(T) <= sizeof(uint16_t),
+                  "Ordinal FactorTableD only supports 8-bit and 16-bit values!");
     constexpr uint64_t MAX_T = pstd::numeric_limits<T>::max();
     constexpr uint64_t MAX_INT64_T = pstd::numeric_limits<int64_t>::max();
-    constexpr uint64_t MAX_M = (MAX_T - 1) * (MAX_T - 1) - 1;
+    constexpr uint64_t MAX_M_NUMERIC = (MAX_T - 1) * (MAX_T - 1) - 1;
+
+    // Codes T_MAX - 1 and T_MAX are reserved for n = 1 and primes.
+    // p(254) = 1609 and p(65534) = 821573 are therefore the first
+    // unencodable least prime factors for 8-bit and 16-bit ordinals.
+    constexpr uint64_t FIRST_UNENCODABLE_PRIME =
+      sizeof(T) == sizeof(uint8_t) ? 1609 : 821573;
+    constexpr uint64_t MAX_M_ORDINAL =
+      FIRST_UNENCODABLE_PRIME * FIRST_UNENCODABLE_PRIME - 1;
+    constexpr uint64_t MAX_M = store_ordinal ? MAX_M_ORDINAL : MAX_M_NUMERIC;
     return (int64_t) std::min(MAX_M, MAX_INT64_T);
   }
 
@@ -248,17 +309,53 @@ public:
   static int64_t max()
   {
     static_assert(sizeof(T) * 2 <= sizeof(uint64_t), "FactorTableD: sizeof(T) is too large!");
+    static_assert(!store_ordinal ||
+                  sizeof(T) <= sizeof(uint16_t),
+                  "Ordinal FactorTableD only supports 8-bit and 16-bit values!");
     uint64_t MAX_T = pstd::numeric_limits<T>::max();
     uint64_t MAX_INT64_T = pstd::numeric_limits<int64_t>::max();
-    uint64_t MAX_M = (MAX_T - 1) * (MAX_T - 1) - 1;
+    uint64_t MAX_M_NUMERIC = (MAX_T - 1) * (MAX_T - 1) - 1;
+    uint64_t FIRST_UNENCODABLE_PRIME =
+      sizeof(T) == sizeof(uint8_t) ? 1609 : 821573;
+    uint64_t MAX_M_ORDINAL =
+      FIRST_UNENCODABLE_PRIME * FIRST_UNENCODABLE_PRIME - 1;
+    uint64_t MAX_M = store_ordinal ? MAX_M_ORDINAL : MAX_M_NUMERIC;
     return (int64_t) std::min(MAX_M, MAX_INT64_T);
   }
 
 #endif
 
 private:
+  static T encode_factor(int64_t prime,
+                         int64_t prime_index)
+  {
+    if (store_ordinal)
+    {
+      ASSERT(prime_index <= (int64_t) pstd::numeric_limits<T>::max() - 2);
+      return (T) prime_index;
+    }
+    else
+      return (T) prime;
+  }
+
+  void toggle_moebius(int64_t index)
+  {
+    if (store_ordinal)
+    {
+      std::size_t word = (std::size_t) index / 64;
+      uint64_t bit = uint64_t(1) << (index % 64);
+      moebius_[word] ^= bit;
+    }
+    else
+      factor_[index] ^= 1;
+  }
+
   Vector<T> factor_;
+  Vector<uint64_t> moebius_;
 };
+
+template <typename T>
+using FactorTableDOrdinal = FactorTableD<T, true>;
 
 } // namespace
 

--- a/test/gourdon/FactorTableD.cpp
+++ b/test/gourdon/FactorTableD.cpp
@@ -34,10 +34,10 @@ void check(bool OK)
 
 int main()
 {
-  check(FactorTableD<uint16_t>::max() == 4294705155ll);
+  check(FactorTableD<uint16_t>::max() == 149060082888ll);
   check(FactorTableD<uint32_t>::max() == pstd::numeric_limits<int64_t>::max());
-  check(FactorTableDOrdinal<uint8_t>::max() == 2588880ll);
-  check(FactorTableDOrdinal<uint16_t>::max() == 674982194328ll);
+  check(FactorTableD<uint16_t>::to_index(
+          FactorTableD<uint16_t>::max()) > UINT32_MAX);
 
   std::random_device rd;
   std::mt19937 gen(rd());
@@ -57,10 +57,9 @@ int main()
     prime_indexes[primes[i]] = (uint32_t) i;
 
   FactorTableD<uint16_t> factorTable(y, z, threads);
-  FactorTableDOrdinal<uint16_t> ordinalTable(y, z, threads);
   int64_t uint16_max = pstd::numeric_limits<uint16_t>::max();
   int64_t limit = factorTable.first_coprime();
-  std::vector<int> filter_primes = { 13, 17, 101, 9973 };
+  std::vector<uint32_t> filter_primes = { 13, 17, 101, 9973 };
 
   for (int64_t n = 1; n <= z; n++)
   {
@@ -76,97 +75,75 @@ int main()
     // have been removed from the FactorTableD.
     if (mpf[n] > y)
     {
-      std::cout << "prime_factor_larger_y(" << n << ") = " << (factorTable.is_leaf(i) == 0);
-      check(factorTable.is_leaf(i) == 0);
-      check(ordinalTable.is_leaf(i) == 0);
+      std::cout << "prime_factor_larger_y(" << n << ") = " << (factorTable[i] == 0);
+      check(factorTable[i] == 0);
       continue;
     }
 
     std::cout << "mu(" << n << ") = " << factorTable.mu(i);
     check(mu[n] == factorTable.mu(i));
-    check(mu[n] == ordinalTable.mu(i));
 
     std::cout << "lpf(" << n << ") = " << lpf[n];
 
-    // is_leaf(n) is a combination of the mu(n) (Möbius function),
-    // lpf(n) (least prime factor) and mpf(n) (max prime factor)
-    // functions. is_leaf(n) returns (with n = to_number(index)):
+    // factorTable[index] is a combination of the mu(n) (Möbius
+    // function), lpf(n) (least prime factor) and mpf(n) (max prime
+    // factor) functions. It returns (with n = to_number(index)):
     //
-    // 1) INT_MAX - 1  if n = 1
-    // 2) INT_MAX      if n is a prime
-    // 3) 0            if n has a prime factor > y
-    // 4) 0            if moebius(n) = 0
-    // 5) lpf - 1      if moebius(n) = 1
-    // 6) lpf          if moebius(n) = -1
+    // 1) INT_MAX - 1    if n = 1
+    // 2) INT_MAX        if n is a prime
+    // 3) 0              if n has a prime factor > y
+    // 4) 0              if moebius(n) = 0
+    // 5) 2*pi(lpf)      if moebius(n) = 1
+    // 6) 2*pi(lpf) + 1  if moebius(n) = -1
 
     if (n == 1)
-    {
-      check(factorTable.is_leaf(i) == uint16_max - 1);
-      check(ordinalTable.is_leaf(i) == uint16_max - 1);
-    }
+      check(factorTable[i] == uint16_max - 1);
     else if (is_prime)
-    {
-      check(factorTable.is_leaf(i) == uint16_max);
-      check(ordinalTable.is_leaf(i) == uint16_max);
-    }
+      check(factorTable[i] == uint16_max);
     else if (mu[n] == 0)
-    {
-      check(factorTable.is_leaf(i) == 0);
-      check(ordinalTable.is_leaf(i) == 0);
-    }
+      check(factorTable[i] == 0);
     else
     {
-      check(lpf[n] == factorTable.is_leaf(i) + (factorTable.mu(i) == 1));
-      check(prime_indexes[lpf[n]] == ordinalTable.is_leaf(i));
+      int64_t expected = prime_indexes[lpf[n]] * 2 + (mu[n] == -1);
+      check(factorTable[i] == expected);
     }
 
-    // The numerical and ordinal encodings must make the same
-    // filtering decision for every prime threshold used by D.
+    // Check that "factor[n] > encode(PrimePi(prime))" is equivalent
+    // to "mu[n] != 0 && lpf[n] > prime" for a few prime thresholds.
+    // (Numbers with mpf[n] > y have already been skipped above).
     if (n != 1)
     {
-      for (int prime : filter_primes)
+      for (uint32_t prime : filter_primes)
       {
-        int64_t prime_index = prime_indexes[prime];
-        bool numerical = factorTable.is_leaf(i) > factorTable.get_filter_value(prime, prime_index);
-        bool ordinal = ordinalTable.is_leaf(i) > ordinalTable.get_filter_value(prime, prime_index);
-        check(numerical == ordinal);
+        if (prime < n)
+        {
+          int64_t prime_index = prime_indexes[prime];
+          bool expected = mu[n] != 0 && lpf[n] > prime;
+          bool actual = factorTable[i] >
+                        FactorTableD<uint16_t>::encode(prime_index);
+          check(actual == expected);
+        }
       }
     }
 
     not_coprime:;
   }
 
-  // Forced small-width boundary test. Codes 254 and 255 are
-  // reserved for n = 1 and primes, hence ordinal 253 is the largest
-  // least-prime ordinal that fits into uint8_t.
-  {
-    int64_t p253 = primesieve::nth_prime(253);
-    int64_t p254 = primesieve::nth_prime(254);
-    int64_t n = p253 * p254;
-    FactorTableDOrdinal<uint8_t> smallOrdinalTable(FactorTableDOrdinal<uint8_t>::max(),
-                                                   FactorTableDOrdinal<uint8_t>::max(),
-                                                   threads);
-    int64_t i = smallOrdinalTable.to_index(n);
-    check(smallOrdinalTable.is_leaf(i) == 253);
-    check(smallOrdinalTable.mu(i) == 1);
-  }
-
   // Compare single-threaded and parallel construction. The larger z
-  // crosses FactorTableD's threading threshold and exercises bitmap
-  // word-aligned thread boundaries.
+  // crosses FactorTableD's threading threshold.
   {
     int64_t parallel_y = 1000000;
     int64_t parallel_z = 10000001;
-    FactorTableDOrdinal<uint16_t> singleThread(parallel_y, parallel_z, 1);
-    FactorTableDOrdinal<uint16_t> multiThread(parallel_y, parallel_z, 2);
+    FactorTableD<uint16_t> singleThread(parallel_y, parallel_z, 1);
+    FactorTableD<uint16_t> multiThread(parallel_y, parallel_z, 2);
     int64_t size = singleThread.to_index(parallel_z) + 1;
     bool equal = true;
 
     for (int64_t i = 0; equal && i < size; i++)
     {
-      equal = singleThread.is_leaf(i) == multiThread.is_leaf(i);
+      equal = singleThread[i] == multiThread[i];
 
-      if (equal && singleThread.is_leaf(i) != 0)
+      if (equal && singleThread[i] != 0)
         equal = singleThread.mu(i) == multiThread.mu(i);
     }
 

--- a/test/gourdon/FactorTableD.cpp
+++ b/test/gourdon/FactorTableD.cpp
@@ -36,6 +36,8 @@ int main()
 {
   check(FactorTableD<uint16_t>::max() == 4294705155ll);
   check(FactorTableD<uint32_t>::max() == pstd::numeric_limits<int64_t>::max());
+  check(FactorTableDOrdinal<uint8_t>::max() == 2588880ll);
+  check(FactorTableDOrdinal<uint16_t>::max() == 674982194328ll);
 
   std::random_device rd;
   std::mt19937 gen(rd());
@@ -49,10 +51,16 @@ int main()
   auto lpf = generate_lpf(z, primes);
   auto mpf = generate_mpf(z, primes);
   auto mu = generate_moebius(z, primes);
+  Vector<uint32_t> prime_indexes(z + 1);
+
+  for (std::size_t i = 1; i < primes.size(); i++)
+    prime_indexes[primes[i]] = (uint32_t) i;
 
   FactorTableD<uint16_t> factorTable(y, z, threads);
+  FactorTableDOrdinal<uint16_t> ordinalTable(y, z, threads);
   int64_t uint16_max = pstd::numeric_limits<uint16_t>::max();
   int64_t limit = factorTable.first_coprime();
+  std::vector<int> filter_primes = { 13, 17, 101, 9973 };
 
   for (int64_t n = 1; n <= z; n++)
   {
@@ -70,11 +78,13 @@ int main()
     {
       std::cout << "prime_factor_larger_y(" << n << ") = " << (factorTable.is_leaf(i) == 0);
       check(factorTable.is_leaf(i) == 0);
+      check(ordinalTable.is_leaf(i) == 0);
       continue;
     }
 
     std::cout << "mu(" << n << ") = " << factorTable.mu(i);
     check(mu[n] == factorTable.mu(i));
+    check(mu[n] == ordinalTable.mu(i));
 
     std::cout << "lpf(" << n << ") = " << lpf[n];
 
@@ -90,15 +100,77 @@ int main()
     // 6) lpf          if moebius(n) = -1
 
     if (n == 1)
+    {
       check(factorTable.is_leaf(i) == uint16_max - 1);
+      check(ordinalTable.is_leaf(i) == uint16_max - 1);
+    }
     else if (is_prime)
+    {
       check(factorTable.is_leaf(i) == uint16_max);
+      check(ordinalTable.is_leaf(i) == uint16_max);
+    }
     else if (mu[n] == 0)
+    {
       check(factorTable.is_leaf(i) == 0);
+      check(ordinalTable.is_leaf(i) == 0);
+    }
     else
+    {
       check(lpf[n] == factorTable.is_leaf(i) + (factorTable.mu(i) == 1));
+      check(prime_indexes[lpf[n]] == ordinalTable.is_leaf(i));
+    }
+
+    // The numerical and ordinal encodings must make the same
+    // filtering decision for every prime threshold used by D.
+    if (n != 1)
+    {
+      for (int prime : filter_primes)
+      {
+        int64_t prime_index = prime_indexes[prime];
+        bool numerical = factorTable.is_leaf(i) > factorTable.get_filter_value(prime, prime_index);
+        bool ordinal = ordinalTable.is_leaf(i) > ordinalTable.get_filter_value(prime, prime_index);
+        check(numerical == ordinal);
+      }
+    }
 
     not_coprime:;
+  }
+
+  // Forced small-width boundary test. Codes 254 and 255 are
+  // reserved for n = 1 and primes, hence ordinal 253 is the largest
+  // least-prime ordinal that fits into uint8_t.
+  {
+    int64_t p253 = primesieve::nth_prime(253);
+    int64_t p254 = primesieve::nth_prime(254);
+    int64_t n = p253 * p254;
+    FactorTableDOrdinal<uint8_t> smallOrdinalTable(FactorTableDOrdinal<uint8_t>::max(),
+                                                   FactorTableDOrdinal<uint8_t>::max(),
+                                                   threads);
+    int64_t i = smallOrdinalTable.to_index(n);
+    check(smallOrdinalTable.is_leaf(i) == 253);
+    check(smallOrdinalTable.mu(i) == 1);
+  }
+
+  // Compare single-threaded and parallel construction. The larger z
+  // crosses FactorTableD's threading threshold and exercises bitmap
+  // word-aligned thread boundaries.
+  {
+    int64_t parallel_y = 1000000;
+    int64_t parallel_z = 10000001;
+    FactorTableDOrdinal<uint16_t> singleThread(parallel_y, parallel_z, 1);
+    FactorTableDOrdinal<uint16_t> multiThread(parallel_y, parallel_z, 2);
+    int64_t size = singleThread.to_index(parallel_z) + 1;
+    bool equal = true;
+
+    for (int64_t i = 0; equal && i < size; i++)
+    {
+      equal = singleThread.is_leaf(i) == multiThread.is_leaf(i);
+
+      if (equal && singleThread.is_leaf(i) != 0)
+        equal = singleThread.mu(i) == multiThread.mu(i);
+    }
+
+    check(equal);
   }
 
   std::cout << std::endl;


### PR DESCRIPTION
Hi kim, this is chopper. I'm a big fan of primecount and when I'm trying to improve the effeciency of primecount, I found a tiny improvement in Gourdon D memory while it didn't slow down the speed. This is found by by interaction with codex, and I hope you can take a look on this minimum patch.

----------------------------------------------------------------------------

This reduces the memory usage of Gourdon's D formula when

FactorTableD<uint16_t>::max() < z <= FactorTableDOrdinal<uint16_t>::max()

by storing least-prime-factor ordinals in 16 bits and the Möbius sign in a separate bitmap.

Benchmark on AMD Ryzen 9 9950X3D, AVX512, 32 threads:

primecount 100000000000000000000 --D --threads=32 \
    --alpha-y=925.267 --alpha-z=1 --time

                           Time            Peak memory
Baseline              58.832 s       5253.4 MiB
Ordinal16           54.675 s       3658.3 MiB

Peak memory: -30.4% (-1595 MiB)
Runtime:     -7.1%

Both versions returned:
1142497794003802599

All tests pass successfully.